### PR TITLE
OEL-718: bcl_timeago filter removed due to it was moved to bootstrap

### DIFF
--- a/modules/oe_whitelabel_helper/README.md
+++ b/modules/oe_whitelabel_helper/README.md
@@ -19,11 +19,6 @@ Enables the [OpenEuropa Multilingual](https://github.com/openeuropa/oe_multiling
 The language switcher block is themed out of the box.
 
 ### Twig helpers
-#### bcl_timeago filter
-Filters a timestamp in "time ago" format, result can be something like "8 hours ago".
-```
-node.getCreatedTime|bcl_timeago
-```
 #### bcl_footer_links function
 Processes oe_corporate_blocks links to make them compatible with BCL formatting.
 ```

--- a/modules/oe_whitelabel_helper/src/TwigExtension/TwigExtension.php
+++ b/modules/oe_whitelabel_helper/src/TwigExtension/TwigExtension.php
@@ -32,77 +32,11 @@ class TwigExtension extends AbstractExtension {
   /**
    * {@inheritdoc}
    */
-  public function getFilters(): array {
-    return [
-      new TwigFilter('bcl_timeago', [$this, 'bclTimeAgo']),
-    ];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getFunctions(): array {
     return [
       new TwigFunction('bcl_footer_links', [$this, 'bclFooterLinks'], ['needs_context' => TRUE]),
       new TwigFunction('bcl_block', [$this, 'bclBlock']),
     ];
-  }
-
-  /**
-   * Filters a timestamp in "time ago" format.
-   *
-   * @param string $timestamp
-   *   Datetime to be parsed.
-   *
-   * @return \Drupal\Core\StringTranslation\PluralTranslatableMarkup
-   *   The translated time ago string.
-   */
-  public function bclTimeAgo(string $timestamp): PluralTranslatableMarkup {
-    $time = \Drupal::time()->getCurrentTime() - $timestamp;
-    $time_ago = new PluralTranslatableMarkup(0, 'N/A', 'N/A');
-    $units = [
-      31536000 => [
-        'singular' => '@number year ago',
-        'plural' => '@number years ago',
-      ],
-      2592000 => [
-        'singular' => '@number month ago',
-        'plural' => '@number months ago',
-      ],
-      604800 => [
-        'singular' => '@number week ago',
-        'plural' => '@number weeks ago',
-      ],
-      86400 => [
-        'singular' => '@number day ago',
-        'plural' => '@number days ago',
-      ],
-      3600 => [
-        'singular' => '@number hour ago',
-        'plural' => '@number hours ago',
-      ],
-      60 => [
-        'singular' => '@number minute ago',
-        'plural' => '@number minutes ago',
-      ],
-      1 => [
-        'singular' => '@number second ago',
-        'plural' => '@number seconds ago',
-      ],
-    ];
-
-    foreach ($units as $unit => $format) {
-      if ($time < $unit) {
-        continue;
-      }
-
-      $number_of_units = floor($time / $unit);
-      $time_ago = \Drupal::translation()
-        ->formatPlural($number_of_units, $format['singular'], $format['plural'], ['@number' => $number_of_units]);
-      break;
-    }
-
-    return $time_ago;
   }
 
   /**

--- a/modules/oe_whitelabel_helper/src/TwigExtension/TwigExtension.php
+++ b/modules/oe_whitelabel_helper/src/TwigExtension/TwigExtension.php
@@ -5,9 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\oe_whitelabel_helper\TwigExtension;
 
 use Drupal\Core\Cache\CacheableDependencyInterface;
-use Drupal\Core\StringTranslation\PluralTranslatableMarkup;
 use Twig\Extension\AbstractExtension;
-use Twig\TwigFilter;
 use Twig\TwigFunction;
 
 /**


### PR DESCRIPTION
Also filter testing was created see --> https://github.com/openeuropa/oe_bootstrap_theme/pull/88