### PR TITLE
Fix displaying HR when pager is not displayed

### DIFF
--- a/templates/overrides/navigation/pager.html.twig
+++ b/templates/overrides/navigation/pager.html.twig
@@ -6,6 +6,8 @@
 #}
 {% extends "@oe_bootstrap_theme/overrides/navigation/pager.html.twig" %}
 {% block pager %}
-  <hr class="d-none d-md-block mt-4-5">
-  {{ parent()}}
+  {% if (parent()) %}
+    <hr class="d-none d-md-block mt-4-5">
+    {{ parent()}}
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
Drupal returns the pager element in the template, even if it's configured to be enabled but it's not displayed because there are no results. This change is to display the HR line only when the pager is displayed. 

Below screenshot:
![MicrosoftTeams-image (3)](https://user-images.githubusercontent.com/10449853/171641102-5c2ef444-c87c-467f-89e0-4a0b6779d7d6.png)

