### PR TITLE
EPHEH-73: Color Schema POC - DO NOT MERGE

### DIFF
--- a/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
+++ b/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
@@ -276,6 +276,9 @@ function oe_whitelabel_preprocess_paragraph__oe_list_item_block(array &$variable
 function oe_whitelabel_preprocess_paragraph__oe_banner(array &$variables): void {
   /** @var Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
+  if ($paragraph->hasField('field_color_schema')) {
+    $variables['attributes']['class'][] = $paragraph->get('field_color_schema')->value;
+  }
   $variables['title'] = $paragraph->get('field_oe_title')->value;
   $variables['description'] = $paragraph->get('field_oe_text')->value;
   $variables['full_width'] = (bool) $paragraph->get('field_oe_banner_full_width')->value;

--- a/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
+++ b/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
@@ -283,7 +283,7 @@ function oe_whitelabel_preprocess_paragraph__oe_banner(array &$variables): void 
 
   // The alignment field value contains the information regarding the pattern
   // type and centering.
-  $alignment = $paragraph->get('field_oe_banner_type')->value;
+  $alignment = $paragraph->get('field_oe_banner_alignment')->value;
   [$banner_type, $banner_alignment] = explode('_', $alignment);
   // The beginning of the string determines the pattern.
   $variables['pattern'] = 'banner_' . $banner_type;

--- a/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
+++ b/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
@@ -276,8 +276,8 @@ function oe_whitelabel_preprocess_paragraph__oe_list_item_block(array &$variable
 function oe_whitelabel_preprocess_paragraph__oe_banner(array &$variables): void {
   /** @var Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
-  if ($paragraph->hasField('field_color_schema')) {
-    $variables['attributes']['class'][] = $paragraph->get('field_color_schema')->value;
+  if ($paragraph->hasField('oe_wt_color_schema')) {
+    $variables['attributes']['class'][] = $paragraph->get('oe_wt_color_schema')->value;
   }
   $variables['title'] = $paragraph->get('field_oe_title')->value;
   $variables['description'] = $paragraph->get('field_oe_text')->value;

--- a/modules/oe_whitlabel_color_schema/config/install/field.storage.node.field_color_schema.yml
+++ b/modules/oe_whitlabel_color_schema/config/install/field.storage.node.field_color_schema.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.oe_wt_color_schema
+field_name: oe_wt_color_schema
+entity_type: node
+type: list_string
+settings:
+  allowed_values: { }
+  allowed_values_function: oe_whitelabel_color_schema_allowed_values
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/oe_whitlabel_color_schema/config/install/field.storage.paragraph.field_color_schema.yml
+++ b/modules/oe_whitlabel_color_schema/config/install/field.storage.paragraph.field_color_schema.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.oe_wt_color_schema
+field_name: oe_wt_color_schema
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values: { }
+  allowed_values_function: oe_whitelabel_color_schema_allowed_values
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/oe_whitlabel_color_schema/oe_whitelabel_color_schema.info.yml
+++ b/modules/oe_whitlabel_color_schema/oe_whitelabel_color_schema.info.yml
@@ -1,0 +1,10 @@
+name: OpenEuropa Whitelabel Color Schema
+type: module
+description: Defines a color schema field.
+package: OpenEuropa Whitelabel Theme
+core_version_requirement: ^9.4 || ^10
+
+config_devel:
+  install:
+    - field.storage.node.oe_wt_color_schema
+    - field.storage.paragraph.oe_wt_color_schema

--- a/modules/oe_whitlabel_color_schema/oe_whitelabel_color_schema.module
+++ b/modules/oe_whitlabel_color_schema/oe_whitelabel_color_schema.module
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @file
+ * The OE Whitelabel Color Schema module.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\Core\Entity\FieldableEntityInterface;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\oe_whitelabel_color_schema\Event\ColorSchemaOptionsEvent;
+
+/**
+ * Sets dynamic allowed values for the color schema fields.
+ *
+ * @param \Drupal\Core\Field\FieldStorageDefinitionInterface $definition
+ *   The field definition.
+ * @param \Drupal\Core\Entity\FieldableEntityInterface|null $entity
+ *   The entity being created if applicable.
+ * @param bool $cacheable
+ *   Boolean indicating if the results are cacheable.
+ *
+ * @return array
+ *   An array of possible key and value color schema options.
+ *
+ * @see options_allowed_values()
+ */
+function oe_whitelabel_color_schema_allowed_values(FieldStorageDefinitionInterface $definition, FieldableEntityInterface $entity = NULL, &$cacheable = TRUE) {
+  $event = new ColorSchemaOptionsEvent();
+
+  $event_dispatcher = \Drupal::service('event_dispatcher');
+  $event_dispatcher->dispatch($event, ColorSchemaOptionsEvent::class);
+
+  return $event->getColorSchemaOptions();
+}

--- a/modules/oe_whitlabel_color_schema/oe_whitelabel_color_schema.services.yml
+++ b/modules/oe_whitlabel_color_schema/oe_whitelabel_color_schema.services.yml
@@ -1,0 +1,5 @@
+services:
+  oe_whitelabel_color_schmea.color_schmea_options_subscriber:
+    class: 'Drupal\oe_whitelabel_color_schema\EventSubscriber\ColorSchemaOptionsSubscriber'
+    tags:
+      - { name: 'event_subscriber' }

--- a/modules/oe_whitlabel_color_schema/src/Event/ColorSchemaOptionsEvent.php
+++ b/modules/oe_whitlabel_color_schema/src/Event/ColorSchemaOptionsEvent.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_whitelabel_color_schema\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Event triggered when a color schema's options need to be provided.
+ */
+class ColorSchemaOptionsEvent extends Event {
+
+  /**
+   * The array containing the allowed values.
+   *
+   * @var array
+   */
+  protected $colorSchemaOptions = [];
+
+  /**
+   * Sets the color schema options list.
+   *
+   * @param array $color_schema_options
+   *   Array containing the set of allowed values for color schema options.
+   */
+  public function setColorSchemaOptions(array $color_schema_options = []): void {
+    $this->colorSchemaOptions = $color_schema_options;
+  }
+
+  /**
+   * Gets the color schema option list values.
+   *
+   * @return array
+   *   Array containing the set of allowed values for color schema options.
+   */
+  public function getColorSchemaOptions(): array {
+    return $this->colorSchemaOptions;
+  }
+
+}

--- a/modules/oe_whitlabel_color_schema/src/EventSubscriber/ColorSchemaOptionsSubscriber.php
+++ b/modules/oe_whitlabel_color_schema/src/EventSubscriber/ColorSchemaOptionsSubscriber.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_whitelabel_color_schema\EventSubscriber;
+
+use Drupal\oe_whitelabel_color_schema\Event\ColorSchemaOptionsEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Provides options for the color schema fields.
+ *
+ * @see \Drupal\oe_paragraphs\EventSubscriber\OptionsSubscriber
+ * @see _oe_whitelabel_allowed_values_color_schema()
+ *
+ * @todo Put this into oe_showcase.
+ */
+class ColorSchemaOptionsSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      ColorSchemaOptionsEvent::class => ['getColorSchemaOptions', -1],
+    ];
+  }
+
+  /**
+   * Gets the icon options.
+   *
+   * @param \Drupal\oe_whitelabel_color_schema\Event\ColorSchemaOptionsEvent $event
+   *   Allowed format event object.
+   */
+  public function getIconOptions(ColorSchemaOptionsEvent $event): void {
+    $event->setColorSchemaOptions([
+      'oewt-color-schema-red' => 'Red',
+      'oewt-color-schema-blue' => 'Blue',
+    ]);
+  }
+
+}

--- a/modules/oe_whitlabel_color_schema/src/EventSubscriber/ColorSchemaOptionsSubscriber.php
+++ b/modules/oe_whitlabel_color_schema/src/EventSubscriber/ColorSchemaOptionsSubscriber.php
@@ -32,7 +32,7 @@ class ColorSchemaOptionsSubscriber implements EventSubscriberInterface {
    * @param \Drupal\oe_whitelabel_color_schema\Event\ColorSchemaOptionsEvent $event
    *   Allowed format event object.
    */
-  public function getIconOptions(ColorSchemaOptionsEvent $event): void {
+  public function getColorSchemaOptions(ColorSchemaOptionsEvent $event): void {
     $event->setColorSchemaOptions([
       'oewt-color-schema-red' => 'Red',
       'oewt-color-schema-blue' => 'Blue',

--- a/oe_whitelabel.theme
+++ b/oe_whitelabel.theme
@@ -9,6 +9,7 @@ declare(strict_types = 1);
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Template\AttributeHelper;
+use Drupal\node\NodeInterface;
 use Drupal\oe_bootstrap_theme_helper\EuropeanUnionLanguages;
 use Drupal\oe_whitelabel\DocumentMediaWrapper;
 
@@ -101,6 +102,18 @@ function oe_whitelabel_preprocess_field(&$variables, $hook, $info) {
     if (isset($variables[$key]['#title_attributes'])) {
       $variables['title_attributes'] = AttributeHelper::mergeCollections($variables['title_attributes'], $variables[$key]['#title_attributes']);
     }
+  }
+}
+
+/**
+ * Implements hook_preprocess_html().
+ */
+function oe_whitelabel_preprocess_html(&$variables) {
+  /** @var \Drupal\node\Entity\Node $node */
+  $node = \Drupal::routeMatch()->getParameter('node');
+
+  if ($node instanceof NodeInterface && $node->hasField('field_color_schema')) {
+    $variables['attributes']['class'][] = $node->get('field_color_schema')->value;
   }
 }
 

--- a/oe_whitelabel.theme
+++ b/oe_whitelabel.theme
@@ -112,8 +112,8 @@ function oe_whitelabel_preprocess_html(&$variables) {
   /** @var \Drupal\node\Entity\Node $node */
   $node = \Drupal::routeMatch()->getParameter('node');
 
-  if ($node instanceof NodeInterface && $node->hasField('field_color_schema')) {
-    $variables['attributes']['class'][] = $node->get('field_color_schema')->value;
+  if ($node instanceof NodeInterface && $node->hasField('oe_wt_color_schema')) {
+    $variables['attributes']['class'][] = $node->get('oe_wt_color_schema')->value;
   }
 }
 

--- a/resources/sass/components/_patterns.scss
+++ b/resources/sass/components/_patterns.scss
@@ -5,3 +5,35 @@
     }
   }
 }
+// @todo Move these into BCL.
+:root {
+  --oewt-color-bg-primary: #495057;
+  --oewt-color-bg-secondary: #f8f9fa;
+  --oewt-color-icons: currentColor;
+}
+.bcl-header--neutral .bcl-header__navbar,
+.bcl-header--neutral .bcl-header__project {
+  background-color: var(--oewt-color-bg-primary);
+}
+.bcl-content-banner {
+  background-color: var(--oewt-color-bg-secondary);
+}
+.bcl-footer--neutral {
+  background-color: var(--oewt-color-bg-primary);
+}
+.bcl-banner {
+  background-color: var(--oewt-color-bg-secondary);
+}
+// @todo Move these into oe_showcase.
+.oewt-color-schema-blue {
+  --oewt-color-bg-primary: DarkBlue;
+  --oewt-color-bg-secondary: DeepSkyBlue;
+  --oewt-color-icons: DodgerBlue;
+  --bs-link-color: DodgerBlue;
+}
+.oewt-color-schema-red {
+  --oewt-color-bg-primary: DarkRed;
+  --oewt-color-bg-secondary: LightCoral;
+  --oewt-color-icons: Salmon;
+  --bs-link-color: DarkRed;
+}

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -29,6 +29,7 @@ drupal:
     - "./vendor/bin/drush en oe_whitelabel_starter_person -y"
     - "./vendor/bin/drush en oe_whitelabel_starter_publication -y"
     - "./vendor/bin/drush en oe_whitelabel_paragraphs -y"
+    - "./vendor/bin/drush en oe_whitelabel_color_schema -y"
     - "./vendor/bin/drush en toolbar -y"
     - "./vendor/bin/drush theme:enable oe_whitelabel -y"
     - "./vendor/bin/drush theme:enable claro -y"

--- a/templates/paragraphs/paragraph--oe-banner.html.twig
+++ b/templates/paragraphs/paragraph--oe-banner.html.twig
@@ -6,7 +6,9 @@
  * @see ./modules/contrib/paragraphs/templates/paragraph.html.twig
  */
 #}
-{% set attributes = create_attribute() %}
+{% if attributes is not defined %}
+  {% set attributes = create_attribute() %}
+{% endif %}
 {% if url %}
   {% set _call_to_action = {
     'label': label,


### PR DESCRIPTION
- define color schemas in the info yml
- the subtheme should override, not inherit these yml color schemas
- we could deliver some default color schemes (designers could present these to clients for out of box usage)
- we need to establish what is the minimal requirement for overriding elements on page level (content banner, menu background)
- deliver the field as a base field in a separate repo, and they could then be removed from display on project level
next step: Prepare the demo, prepare 2 color schemes