### PR TITLE
OEL-2255: Improvemens over slim_select handling.

### DIFF
--- a/oe_whitelabel.theme
+++ b/oe_whitelabel.theme
@@ -214,7 +214,7 @@ function _oe_whitelabel_process_element_select(array &$element): array {
 
   $element['#attributes']['class'][] = 'multi-select';
   // Config is empty so that it uses the defaults.
-  $element['#slim_select'] = [];
+  $element += ['#slim_select' => []];
 
   return $element;
 }

--- a/resources/sass/components/_forms.scss
+++ b/resources/sass/components/_forms.scss
@@ -1,0 +1,6 @@
+// Prevent double borders on select elements with slim-select enabled.
+.form-select {
+  .ss-multi-selected {
+    border: 0;
+  }
+}

--- a/resources/sass/default.style.scss
+++ b/resources/sass/default.style.scss
@@ -1,3 +1,4 @@
+@import "components/forms";
 @import "components/facets";
 @import "components/list_pages";
 @import "components/patterns";


### PR DESCRIPTION
Prevent double border when the select is multivalue. Avoid overriding existing slim_select settings.