### PR TITLE
UCPKN-3056: Agenda theming.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "mikey179/vfsstream": "^1.6.10",
         "nikic/php-parser": "^4",
         "openeuropa/code-review": "^2.0.0-alpha6",
+        "openeuropa/oe_agenda": "^1.0.0-alpha2",
         "openeuropa/oe_authentication": "^1.11",
         "openeuropa/oe_contact_forms": "~1.11",
         "openeuropa/oe_content": "^3",
@@ -56,12 +57,16 @@
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",
         "post-update-cmd": "./vendor/bin/run drupal:site-setup"
     },
-    "repositories": [
-        {
+    "repositories": {
+        "oe_agenda": {
+            "type": "git",
+            "url": "https://github.com/openeuropa/oe_agenda"
+        },
+        "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         }
-    ],
+    },
     "autoload": {
         "psr-4": {
             "Drupal\\oe_whitelabel\\": "./src/"

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "mikey179/vfsstream": "^1.6.10",
         "nikic/php-parser": "^4",
         "openeuropa/code-review": "^2.0.0-alpha6",
-        "openeuropa/oe_agenda": "^1.0.0-alpha2",
+        "openeuropa/oe_agenda": "1.x-dev",
         "openeuropa/oe_authentication": "^1.11",
         "openeuropa/oe_contact_forms": "~1.11",
         "openeuropa/oe_content": "^3",

--- a/modules/oe_whitelabel_agenda/config/install/core.date_format.oe_whitelabel_agenda_day_date.yml
+++ b/modules/oe_whitelabel_agenda/config/install/core.date_format.oe_whitelabel_agenda_day_date.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: oe_whitelabel_agenda_day_date
+label: 'OE Whitelabel Agenda day date'
+locked: false
+pattern: 'l - j F'

--- a/modules/oe_whitelabel_agenda/config/overrides/core.entity_view_display.oe_agenda_day.oe_default.default.yml
+++ b/modules/oe_whitelabel_agenda/config/overrides/core.entity_view_display.oe_agenda_day.oe_default.default.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.oe_agenda_day.oe_default.oe_day_date
+    - field.field.oe_agenda_day.oe_default.oe_day_sessions
+    - oe_agenda.oe_agenda_day_type.oe_default
+  module:
+    - datetime
+    - entity_reference_revisions
+id: oe_agenda_day.oe_default.default
+targetEntityType: oe_agenda_day
+bundle: oe_default
+mode: default
+content:
+  oe_day_date:
+    type: datetime_default
+    label: above
+    settings:
+      timezone_override: ''
+      format_type: oe_whitelabel_agenda_day_date
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  oe_day_sessions:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 2
+    region: content
+hidden: {  }

--- a/modules/oe_whitelabel_agenda/config/overrides/core.entity_view_display.oe_agenda_session.oe_break.default.yml
+++ b/modules/oe_whitelabel_agenda/config/overrides/core.entity_view_display.oe_agenda_session.oe_break.default.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.oe_agenda_session.oe_break.oe_session_details
+    - field.field.oe_agenda_session.oe_break.oe_session_hours
+    - oe_agenda.oe_agenda_session_type.oe_break
+  module:
+    - text
+    - time_field
+id: oe_agenda_session.oe_break.default
+targetEntityType: oe_agenda_session
+bundle: oe_break
+mode: default
+content:
+  oe_session_details:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  oe_session_hours:
+    type: time_range_formatter
+    label: above
+    settings:
+      time_format: 'G:i'
+      timerange_format: 'start - end'
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/modules/oe_whitelabel_agenda/config/overrides/core.entity_view_display.oe_agenda_session.oe_default.default.yml
+++ b/modules/oe_whitelabel_agenda/config/overrides/core.entity_view_display.oe_agenda_session.oe_default.default.yml
@@ -1,0 +1,88 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.oe_agenda_session.oe_default.oe_session_details
+    - field.field.oe_agenda_session.oe_default.oe_session_hours
+    - field.field.oe_agenda_session.oe_default.oe_session_intro
+    - field.field.oe_agenda_session.oe_default.oe_session_moderators
+    - field.field.oe_agenda_session.oe_default.oe_session_online_link
+    - field.field.oe_agenda_session.oe_default.oe_session_speakers
+    - field.field.oe_agenda_session.oe_default.oe_session_venue
+    - oe_agenda.oe_agenda_session_type.oe_default
+  module:
+    - entity_reference_revisions
+    - link_description
+    - text
+    - time_field
+id: oe_agenda_session.oe_default.default
+targetEntityType: oe_agenda_session
+bundle: oe_default
+mode: default
+content:
+  oe_session_details:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  oe_session_hours:
+    type: time_range_formatter
+    label: above
+    settings:
+      time_format: 'G:i'
+      timerange_format: 'start - end'
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  oe_session_intro:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  oe_session_moderators:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  oe_session_online_link:
+    type: link_description
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  oe_session_speakers:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  oe_session_venue:
+    type: link_description
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 4
+    region: content
+hidden: {  }

--- a/modules/oe_whitelabel_agenda/oe_whitelabel_agenda.info.yml
+++ b/modules/oe_whitelabel_agenda/oe_whitelabel_agenda.info.yml
@@ -5,3 +5,7 @@ package: OpenEuropa Whitelabel Theme
 core_version_requirement: ^10
 dependencies:
   - oe_agenda:oe_agenda
+
+config_devel:
+  install:
+    - core.date_format.oe_whitelabel_agenda_day_date

--- a/modules/oe_whitelabel_agenda/oe_whitelabel_agenda.info.yml
+++ b/modules/oe_whitelabel_agenda/oe_whitelabel_agenda.info.yml
@@ -1,0 +1,7 @@
+name: OpenEuropa Whitelabel Agenda
+type: module
+description: Companion module to add support for OE Agenda.
+package: OpenEuropa Whitelabel Theme
+core_version_requirement: ^10
+dependencies:
+  - oe_agenda:oe_agenda

--- a/modules/oe_whitelabel_agenda/oe_whitelabel_agenda.install
+++ b/modules/oe_whitelabel_agenda/oe_whitelabel_agenda.install
@@ -18,6 +18,11 @@ function oe_whitelabel_agenda_install(bool $is_syncing): void {
     return;
   }
 
-  // Import agenda day default view display override.
-  ConfigImporter::importSingle('module', 'oe_whitelabel_agenda', '/config/overrides/', 'core.entity_view_display.oe_agenda_day.oe_default.default');
+  // Import config overrides for default view displays of agenda entities.
+  $configs = [
+    'core.entity_view_display.oe_agenda_day.oe_default.default',
+    'core.entity_view_display.oe_agenda_session.oe_default.default',
+    'core.entity_view_display.oe_agenda_session.oe_break.default',
+  ];
+  ConfigImporter::importMultiple('module', 'oe_whitelabel_agenda', '/config/overrides/', $configs);
 }

--- a/modules/oe_whitelabel_agenda/oe_whitelabel_agenda.install
+++ b/modules/oe_whitelabel_agenda/oe_whitelabel_agenda.install
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Install and update functions for the OE Whitelabel Agenda module.
+ */
+
+declare(strict_types=1);
+
+use Drupal\oe_bootstrap_theme\ConfigImporter;
+
+/**
+ * Implements hook_install().
+ */
+function oe_whitelabel_agenda_install(bool $is_syncing): void {
+  if ($is_syncing) {
+    // The module is being installed as part of a config import.
+    return;
+  }
+
+  // Import agenda day default view display override.
+  ConfigImporter::importSingle('module', 'oe_whitelabel_agenda', '/config/overrides/', 'core.entity_view_display.oe_agenda_day.oe_default.default');
+}

--- a/modules/oe_whitelabel_agenda/oe_whitelabel_agenda.module
+++ b/modules/oe_whitelabel_agenda/oe_whitelabel_agenda.module
@@ -65,6 +65,9 @@ function oe_whitelabel_agenda_preprocess_oe_agenda_session__oe_default(array &$v
         'name' => 'box-arrow-up-right',
         'size' => 'xs',
       ];
+      $link['#fields']['attributes'] = [
+        'target' => '_blank',
+      ];
     }
     $definition[] = $link;
 

--- a/modules/oe_whitelabel_agenda/oe_whitelabel_agenda.module
+++ b/modules/oe_whitelabel_agenda/oe_whitelabel_agenda.module
@@ -7,8 +7,12 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Render\Element;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\link_description\Plugin\Field\FieldType\LinkDescriptionItem;
 use Drupal\oe_agenda\Entity\DayInterface;
+use Drupal\oe_agenda\Entity\SessionInterface;
 
 /**
  * Implements hook_preprocess_oe_agenda() for oe_default agenda.
@@ -21,6 +25,70 @@ function oe_whitelabel_agenda_preprocess_oe_agenda__oe_default(array &$variables
     $variables['days'][] = [
       'title' => $day->get('oe_day_date')->first()->view('default'),
       'content' => $variables['content']['oe_agenda_days'][$index],
+    ];
+  }
+}
+
+/**
+ * Implements hook_preprocess_oe_agenda_session() for oe_default session.
+ */
+function oe_whitelabel_agenda_preprocess_oe_agenda_session__oe_default(array &$variables): void {
+  $session = $variables['entity'];
+  assert($session instanceof SessionInterface);
+  $renderer = \Drupal::service('renderer');
+  assert($renderer instanceof RendererInterface);
+
+  // Build items for description list pattern displaying session links.
+  $items = [];
+  foreach (['oe_session_venue', 'oe_session_online_link'] as $index => $field_name) {
+    $field = $session->get($field_name);
+    assert($field instanceof FieldItemListInterface);
+    if ($field->isEmpty() || !$field->access()) {
+      continue;
+    }
+    $items[$index]['term'] = $field->getFieldDefinition()->getLabel() . ':';
+    $definition = [];
+    $link_description_item = $field->first();
+    assert($link_description_item instanceof LinkDescriptionItem);
+
+    // Add link to definition.
+    $link = [
+      '#type' => 'pattern',
+      '#id' => 'link',
+      '#fields' => [
+        'label' => $link_description_item->getTitle(),
+        'path' => $link_description_item->getUrl(),
+      ],
+    ];
+    if ($link_description_item->isExternal()) {
+      $link['#fields']['icon'] = [
+        'name' => 'box-arrow-up-right',
+        'size' => 'xs',
+      ];
+    }
+    $definition[] = $link;
+
+    // Add link description to definition.
+    if (!empty($link_description_item->description)) {
+      $definition[] = [
+        '#type' => 'processed_text',
+        '#text' => $link_description_item->description,
+        '#format' => 'plain_text',
+      ];
+    }
+
+    $items[$index]['definition'] = $renderer->render($definition);
+  }
+
+  // Build description list with session links.
+  if ($items) {
+    $variables['session_links'] = [
+      '#type' => 'pattern',
+      '#id' => 'description_list',
+      '#orientation' => 'horizontal',
+      '#fields' => [
+        'items' => $items,
+      ],
     ];
   }
 }

--- a/modules/oe_whitelabel_agenda/oe_whitelabel_agenda.module
+++ b/modules/oe_whitelabel_agenda/oe_whitelabel_agenda.module
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Render\RendererInterface;
@@ -37,13 +38,22 @@ function oe_whitelabel_agenda_preprocess_oe_agenda_session__oe_default(array &$v
   assert($session instanceof SessionInterface);
   $renderer = \Drupal::service('renderer');
   assert($renderer instanceof RendererInterface);
+  $cacheability = CacheableMetadata::createFromRenderArray($variables);
 
   // Build items for description list pattern displaying session links.
   $items = [];
   foreach (['oe_session_venue', 'oe_session_online_link'] as $index => $field_name) {
     $field = $session->get($field_name);
     assert($field instanceof FieldItemListInterface);
-    if ($field->isEmpty() || !$field->access()) {
+    if ($field->isEmpty()) {
+      // Skip if field is empty.
+      continue;
+    }
+    $access = $field->access('view', $variables['user'], TRUE);
+    $cacheability->addCacheableDependency($access);
+    if (!$access->isAllowed()) {
+      // Skip if user doesn't have access to the field.
+      $cacheability->applyTo($variables);
       continue;
     }
     $items[$index]['term'] = $field->getFieldDefinition()->getLabel() . ':';
@@ -94,4 +104,6 @@ function oe_whitelabel_agenda_preprocess_oe_agenda_session__oe_default(array &$v
       ],
     ];
   }
+
+  $cacheability->applyTo($variables);
 }

--- a/modules/oe_whitelabel_agenda/oe_whitelabel_agenda.module
+++ b/modules/oe_whitelabel_agenda/oe_whitelabel_agenda.module
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @file
+ * OE Whitelabel Agenda module.
+ */
+
+declare(strict_types=1);
+
+use Drupal\Core\Render\Element;
+use Drupal\oe_agenda\Entity\DayInterface;
+
+/**
+ * Implements hook_preprocess_oe_agenda() for oe_default agenda.
+ */
+function oe_whitelabel_agenda_preprocess_oe_agenda__oe_default(array &$variables): void {
+  foreach (Element::children($variables['content']['oe_agenda_days']) as $index) {
+    $day = $variables['content']['oe_agenda_days'][$index]['#oe_agenda_day'];
+    assert($day instanceof DayInterface);
+    // Pass agenda days as accordion items to the template.
+    $variables['days'][] = [
+      'title' => $day->get('oe_day_date')->first()->view('default'),
+      'content' => $variables['content']['oe_agenda_days'][$index],
+    ];
+  }
+}

--- a/modules/oe_whitelabel_agenda/tests/modules/oe_whitelabel_agenda_test/config/overrides/core.entity_view_display.oe_agenda_session.oe_default.default.yml
+++ b/modules/oe_whitelabel_agenda/tests/modules/oe_whitelabel_agenda_test/config/overrides/core.entity_view_display.oe_agenda_session.oe_default.default.yml
@@ -1,0 +1,91 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.oe_agenda_session.oe_default.oe_session_details
+    - field.field.oe_agenda_session.oe_default.oe_session_hours
+    - field.field.oe_agenda_session.oe_default.oe_session_intro
+    - field.field.oe_agenda_session.oe_default.oe_session_moderators
+    - field.field.oe_agenda_session.oe_default.oe_session_online_link
+    - field.field.oe_agenda_session.oe_default.oe_session_speakers
+    - field.field.oe_agenda_session.oe_default.oe_session_venue
+    - oe_agenda.oe_agenda_session_type.oe_default
+  module:
+    - entity_reference_revisions
+    - link_description
+    - oe_content_sub_entity_person
+    - text
+    - time_field
+id: oe_agenda_session.oe_default.default
+targetEntityType: oe_agenda_session
+bundle: oe_default
+mode: default
+content:
+  oe_session_details:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
+  oe_session_hours:
+    type: time_range_formatter
+    label: above
+    settings:
+      time_format: 'G:i'
+      timerange_format: 'start - end'
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  oe_session_intro:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  oe_session_moderators:
+    type: oe_content_sub_entity_person_reference_formatter
+    label: above
+    settings:
+      label_only: 0
+      rel: 0
+      target: 0
+    third_party_settings: {  }
+    weight: 6
+    region: content
+  oe_session_online_link:
+    type: link_description
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 5
+    region: content
+  oe_session_speakers:
+    type: oe_content_sub_entity_person_reference_formatter
+    label: above
+    settings:
+      label_only: 0
+      rel: 0
+      target: 0
+    third_party_settings: {  }
+    weight: 7
+    region: content
+  oe_session_venue:
+    type: link_description
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 4
+    region: content
+hidden: {  }

--- a/modules/oe_whitelabel_agenda/tests/modules/oe_whitelabel_agenda_test/config/overrides/field.field.oe_agenda_session.oe_default.oe_session_moderators.yml
+++ b/modules/oe_whitelabel_agenda/tests/modules/oe_whitelabel_agenda_test/config/overrides/field.field.oe_agenda_session.oe_default.oe_session_moderators.yml
@@ -1,0 +1,35 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.oe_agenda_session.oe_session_moderators
+    - oe_agenda.oe_agenda_session_type.oe_default
+    - oe_content_sub_entity_person.oe_person_type.test_person_type
+  module:
+    - composite_reference
+    - entity_reference_revisions
+third_party_settings:
+  composite_reference:
+    composite: false
+    composite_revisions: false
+id: oe_agenda_session.oe_default.oe_session_moderators
+field_name: oe_session_moderators
+entity_type: oe_agenda_session
+bundle: oe_default
+label: Moderators
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:oe_person'
+  handler_settings:
+    target_bundles:
+      test_person_type: test_person_type
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference_revisions

--- a/modules/oe_whitelabel_agenda/tests/modules/oe_whitelabel_agenda_test/config/overrides/field.field.oe_agenda_session.oe_default.oe_session_speakers.yml
+++ b/modules/oe_whitelabel_agenda/tests/modules/oe_whitelabel_agenda_test/config/overrides/field.field.oe_agenda_session.oe_default.oe_session_speakers.yml
@@ -1,0 +1,35 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.oe_agenda_session.oe_session_speakers
+    - oe_agenda.oe_agenda_session_type.oe_default
+    - oe_content_sub_entity_person.oe_person_type.test_person_type
+  module:
+    - composite_reference
+    - entity_reference_revisions
+third_party_settings:
+  composite_reference:
+    composite: false
+    composite_revisions: false
+id: oe_agenda_session.oe_default.oe_session_speakers
+field_name: oe_session_speakers
+entity_type: oe_agenda_session
+bundle: oe_default
+label: Speakers
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:oe_person'
+  handler_settings:
+    target_bundles:
+      test_person_type: test_person_type
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference_revisions

--- a/modules/oe_whitelabel_agenda/tests/modules/oe_whitelabel_agenda_test/oe_whitelabel_agenda_test.info.yml
+++ b/modules/oe_whitelabel_agenda/tests/modules/oe_whitelabel_agenda_test/oe_whitelabel_agenda_test.info.yml
@@ -1,0 +1,11 @@
+name: OpenEuropa Whitelabel Agenda Test
+description: Test module for OpenEuropa Whitelabel Agenda.
+package: Testing
+
+type: module
+core_version_requirement: ^10
+hidden: true
+
+dependencies:
+  - oe_whitelabel_agenda:oe_whitelabel_agenda
+  - oe_agenda_test:oe_agenda_test

--- a/modules/oe_whitelabel_agenda/tests/modules/oe_whitelabel_agenda_test/oe_whitelabel_agenda_test.install
+++ b/modules/oe_whitelabel_agenda/tests/modules/oe_whitelabel_agenda_test/oe_whitelabel_agenda_test.install
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Install and update functions for the OE Whitelabel Agenda Test module.
+ */
+
+declare(strict_types=1);
+
+use Drupal\oe_bootstrap_theme\ConfigImporter;
+
+/**
+ * Implements hook_install().
+ */
+function oe_whitelabel_agenda_test_install(bool $is_syncing): void {
+  if ($is_syncing) {
+    // The module is being installed as part of a config import.
+    return;
+  }
+
+  // Import config overrides for agenda theming test.
+  $configs = [
+    'field.field.oe_agenda_session.oe_default.oe_session_moderators',
+    'field.field.oe_agenda_session.oe_default.oe_session_speakers',
+    'core.entity_view_display.oe_agenda_session.oe_default.default',
+  ];
+  ConfigImporter::importMultiple('module', 'oe_whitelabel_agenda_test', '/config/overrides/', $configs);
+}

--- a/modules/oe_whitelabel_agenda/tests/src/Kernel/AgendaRenderTest.php
+++ b/modules/oe_whitelabel_agenda/tests/src/Kernel/AgendaRenderTest.php
@@ -1,0 +1,419 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\oe_whitelabel_agenda\Kernel;
+
+use Drupal\Tests\oe_bootstrap_theme\PatternAssertion\IconPatternAssert;
+use Drupal\Tests\oe_bootstrap_theme\PatternAssertion\LinkPatternAssert;
+use Drupal\Tests\oe_whitelabel\Kernel\AbstractKernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\oe_agenda\Entity\Agenda;
+use Drupal\oe_agenda\Entity\AgendaInterface;
+use Drupal\oe_agenda\Entity\Day as AgendaDay;
+use Drupal\oe_agenda\Entity\Session as AgendaSession;
+use Drupal\oe_agenda\Entity\SessionInterface;
+use Drupal\oe_content_sub_entity_person\Entity\Person;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Tests that the agenda renders with the correct markup.
+ */
+class AgendaRenderTest extends AbstractKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $configSchemaCheckerExclusions = [
+    // Schema checker fails when trying to import the config.
+    // See: https://github.com/openeuropa/oe_content/issues/634
+    // @todo remove when fixed in oe_content.
+    'core.entity_view_display.oe_agenda_session.oe_default.default',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'composite_reference',
+    'datetime',
+    'entity_reference_revisions',
+    'field',
+    'filter',
+    'inline_entity_form',
+    'link',
+    'link_description',
+    'node',
+    'oe_content_entity',
+    'oe_content_sub_entity',
+    'oe_content_sub_entity_person',
+    'oe_agenda',
+    'oe_agenda_test',
+    'oe_whitelabel_agenda',
+    'oe_whitelabel_agenda_test',
+    'ui_patterns',
+    'system',
+    'text',
+    'twig_field_value',
+    'time_field',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('oe_agenda');
+    $this->installEntitySchema('oe_agenda_day');
+    $this->installEntitySchema('oe_agenda_session');
+    $this->installEntitySchema('oe_person');
+    $this->installConfig([
+      'filter',
+      'node',
+      'oe_agenda',
+      'oe_agenda_test',
+      'oe_whitelabel_agenda',
+      'oe_content_sub_entity_person',
+    ]);
+
+    \Drupal::moduleHandler()->loadInclude('oe_whitelabel_agenda', 'install');
+    oe_whitelabel_agenda_install(FALSE);
+    \Drupal::moduleHandler()->loadInclude('oe_whitelabel_agenda_test', 'install');
+    oe_whitelabel_agenda_test_install(FALSE);
+  }
+
+  /**
+   * Tests that agenda is rendered with the correct markup.
+   */
+  public function testRendering(): void {
+    $render = \Drupal::entityTypeManager()
+      ->getViewBuilder('oe_agenda')
+      ->view($this->createAgenda());
+    $html = $this->renderRoot($render);
+    $crawler = new Crawler($html);
+
+    // Assert agenda wrapper.
+    $agenda = $crawler->filter('.oe-agenda.accordion');
+    $this->assertCount(1, $agenda);
+
+    // Assert number of agenda days.
+    $days = $agenda->children('.accordion-item');
+    $this->assertCount(2, $days);
+    // Assert all agenda days are collapsed.
+    $this->assertCount(2, $crawler->filter('.accordion-button.collapsed'));
+
+    // Assert Day 1 date is displayed in the correct format.
+    $wrapper = $crawler->filter('#heading-bcl-accordion-1 .accordion-button time');
+    $this->assertEquals('Thursday - 26 September', $wrapper->text());
+
+    // Assert Day 2 date is displayed in the correct format.
+    $wrapper = $crawler->filter('#heading-bcl-accordion-2 .accordion-button time');
+    $this->assertEquals('Friday - 27 September', $wrapper->text());
+
+    // Assert Day 2 title is displayed.
+    $wrapper = $days->eq(1)->filter('.accordion-body > h3');
+    $this->assertEquals('Day 2 Title', $wrapper->text());
+
+    // Assert number of sessions on Day 1.
+    $sessions = $days->eq(0)->filter('.accordion-body > div');
+    $this->assertCount(3, $sessions);
+
+    // Assert Session 1 layout.
+    $session_left_col_selector = '.row .col-xxl-2.col-xl-3.col-lg-3.mb-3.mb-lg-0';
+    $session_left_col = $sessions->eq(0)->filter($session_left_col_selector);
+    $this->assertCount(1, $session_left_col);
+    $session_right_col_selector = '.row .session-content.col-xxl-10.col-xl-9.col-lg-9';
+    $session_right_col = $sessions->eq(0)->filter($session_right_col_selector);
+    $this->assertCount(1, $session_right_col);
+
+    // Assert Day 1 Session 1 icon and time are displayed.
+    $this->assertSessionHours([
+      'from' => '9:00',
+      'to' => '10:30',
+    ], $session_left_col);
+
+    // Assert Day 1 Session 1 title is displayed.
+    $wrapper = $session_right_col->filter('h4.h5:first-child');
+    $this->assertEquals('Session 1 Title', $wrapper->text());
+
+    // Select Day 1 Session 1 section wrappers.
+    $session_sections = $session_right_col->children('div.mb-4-5');
+
+    // Assert Day 1 Session 1 intro is displayed.
+    $this->assertEquals('Session 1 introduction.', $session_sections->eq(0)->text());
+
+    // Assert Day 1 Session 1 moderators are displayed.
+    $this->assertEquals('Moderators', $session_sections->eq(1)->filter('h5.mb-4')->text());
+    $this->assertEquals('Phasellus Viverra', $session_sections->eq(1)->filter('div.mb-2 a')->text());
+    $this->assertEquals('Sed Hendrerit', $session_sections->eq(1)->filter('div:last-child a')->text());
+
+    // Assert Day 1 Session 1 speakers are displayed.
+    $this->assertEquals('Speakers', $session_sections->eq(2)->filter('h5.mb-4')->text());
+    $this->assertEquals('Pellentesque Habitant', $session_sections->eq(2)->filter('div.mb-3 a')->text());
+    $this->assertEquals('Vestibulum Curabitur', $session_sections->eq(2)->filter('div:last-child a')->text());
+
+    // Assert Day 1 Session 1 venue and online link are displayed.
+    $description_list = $session_sections->eq(3)->filter('.bcl-description-list');
+    $link_wrappers = $description_list->filter('dl.mb-3.row');
+    $this->assertEquals('Venue:', $link_wrappers->eq(0)->filter('.col-md-3 dt')->text());
+    $venue_details = $link_wrappers->eq(0)->filter('.col dd div');
+    $link_assert = new LinkPatternAssert();
+    $link_assert->assertPattern([
+      'label' => 'Venue link text',
+      'path' => '/node/1',
+    ], $venue_details->children('a')->outerHtml());
+    $this->assertEquals('Venue description', $venue_details->children('p')->text());
+    $this->assertEquals('Online link:', $link_wrappers->eq(1)->filter('.col-md-3 dt')->text());
+    $online_link_details = $link_wrappers->eq(1)->filter('.col dd div');
+    $online_link = $online_link_details->children('a');
+    $link_assert->assertPattern([
+      'label' => 'Online link text',
+      'path' => 'https://example.com',
+      'settings' => [
+        'icon_position' => 'after',
+      ],
+      'attributes' => [
+        'target' => '_blank',
+      ],
+    ], $online_link->outerHtml());
+    // Can't use LinkPatternAssert for the icon, as it hard-codes the icon size.
+    $icon_assert = new IconPatternAssert();
+    $icon_assert->assertPattern([
+      'name' => 'box-arrow-up-right',
+      'size' => 'xs',
+    ], $online_link->children('svg')->outerHtml());
+    $this->assertEquals('Online link description', $online_link_details->children('p')->text());
+
+    // Assert Day 1 Session 1 details section is displayed.
+    $this->assertEquals('Session 1 details.', $session_right_col->children('.session-details')->text());
+
+    // Assert Day 1 Session 2 (Break) layout.
+    $session_2_left_col = $sessions->eq(1)->filter($session_left_col_selector);
+    $this->assertCount(1, $session_2_left_col);
+    $session_2_right_col = $sessions->eq(1)->filter($session_right_col_selector);
+    $this->assertCount(1, $session_2_right_col);
+
+    // Assert Day 1 Session 2 (Break) icon and time are displayed.
+    $this->assertSessionHours([
+      'session_type' => 'oe_break',
+      'from' => '10:30',
+      'to' => '11:00',
+    ], $session_2_left_col);
+
+    // Assert Day 1 Session 2 (Break) title is displayed.
+    $wrapper = $session_2_right_col->filter('h4.h5.text-muted:first-child');
+    $this->assertEquals('Break', $wrapper->text());
+
+    // Assert Day 1 Session 2 (Break) details section is displayed.
+    $this->assertEquals('Session 2 (Break) details.', $session_2_right_col->children('.session-details')->text());
+
+    // Assert Day 2 Session 2 (Break) custom title is displayed.
+    $day_2_sessions = $days->eq(1)->filter('.accordion-body > div');
+    $day_2_session_2_right_col = $day_2_sessions->eq(1)->filter($session_right_col_selector);
+    $wrapper = $day_2_session_2_right_col->filter('h4.h5.text-muted:first-child');
+    $this->assertEquals('Break Custom Title', $wrapper->text());
+  }
+
+  /**
+   * Asserts the session hours.
+   *
+   * @param array $expected
+   *   The expected settings.
+   * @param \Symfony\Component\DomCrawler\Crawler $crawler
+   *   The crawler.
+   */
+  protected function assertSessionHours(array $expected, Crawler $crawler): void {
+    $session_type = $expected['session_type'] ?? 'oe_default';
+    $from = $expected['from'] ?? '';
+    $to = $expected['to'] ?? '';
+
+    $icon_assert = new IconPatternAssert();
+    $icon = $crawler->children('svg');
+    $this->assertCount(1, $icon);
+    $icon_assert->assertPattern([
+      'name' => 'clock',
+      'size' => 'xs',
+      'attributes' => [
+        'class' => 'mb-1 me-2 bi icon--xs',
+      ],
+    ], $icon->outerHtml());
+    $time_wrapper_selector = $session_type === 'oe_break' ? 'span.text-muted' : 'span';
+    $this->assertEquals("{$from} - {$to}", $crawler->children($time_wrapper_selector)->text());
+  }
+
+  /**
+   * Creates an agenda using data for testing.
+   *
+   * @return \Drupal\oe_agenda\Entity\AgendaInterface
+   *   The created test agenda.
+   */
+  protected function createAgenda(): AgendaInterface {
+    $days = [
+      [
+        'date' => '2024-09-26',
+        'sessions' => [
+          [
+            'hours' => [
+              'from' => 32400,
+              'to' => 37800,
+            ],
+            'name' => 'Session 1 Title',
+            'intro' => 'Session 1 introduction.',
+            'moderators' => $this->createPersons([
+              'Phasellus Viverra',
+              'Sed Hendrerit',
+            ]),
+            'speakers' => $this->createPersons([
+              'Pellentesque Habitant',
+              'Vestibulum Curabitur',
+            ]),
+            'venue' => [
+              'uri' => 'entity:node/1',
+              'title' => 'Venue link text',
+              'description' => 'Venue description',
+            ],
+            'online_link' => [
+              'uri' => 'https://example.com',
+              'title' => 'Online link text',
+              'description' => 'Online link description',
+            ],
+            'details' => 'Session 1 details.',
+          ],
+          [
+            'type' => 'oe_break',
+            'hours' => [
+              'from' => 37800,
+              'to' => 39600,
+            ],
+            'details' => 'Session 2 (Break) details.',
+          ],
+          [
+            'hours' => [
+              'from' => 39600,
+              'to' => 43200,
+            ],
+          ],
+        ],
+      ],
+      [
+        'date' => '2024-09-27',
+        'title' => 'Day 2 Title',
+        'sessions' => [
+          [
+            'hours' => [
+              'from' => 30600,
+              'to' => 34200,
+            ],
+          ],
+          [
+            'type' => 'oe_break',
+            'name' => 'Break Custom Title',
+            'hours' => [
+              'from' => 34200,
+              'to' => 35100,
+            ],
+          ],
+        ],
+      ],
+    ];
+
+    $agenda_days = [];
+    foreach ($days as $day) {
+      $agenda_sessions = [];
+      foreach ($day['sessions'] as $session_data) {
+        $agenda_sessions[] = $this->createAgendaSession($session_data);
+      }
+
+      $agenda_day = AgendaDay::create([
+        'type' => 'oe_default',
+        'oe_day_date' => $day['date'],
+        'oe_day_sessions' => $agenda_sessions,
+      ]);
+      if (!empty($day['title'])) {
+        $agenda_day->set('title', $day['title']);
+      }
+      $agenda_day->save();
+      $agenda_days[] = $agenda_day;
+    }
+
+    $agenda = Agenda::create([
+      'type' => 'oe_default',
+      'oe_agenda_days' => $agenda_days,
+    ]);
+    $agenda->save();
+
+    return $agenda;
+  }
+
+  /**
+   * Creates an agenda session using data for testing.
+   *
+   * @return \Drupal\oe_agenda\Entity\SessionInterface
+   *   The created test agenda session.
+   */
+  protected function createAgendaSession(array $session_data): SessionInterface {
+    $session_type = $session_data['type'] ?? 'oe_default';
+    $from = $session_data['hours']['from'] ?? 0;
+    $to = $session_data['hours']['to'] ?? 3600;
+    $session = AgendaSession::create([
+      'type' => $session_type,
+      'oe_session_hours' => [
+        'from' => $from,
+        'to' => $to,
+      ],
+    ]);
+    if (!empty($session_data['name'])) {
+      $session->set('name', $session_data['name']);
+    }
+    if (!empty($session_data['intro'])) {
+      $session->set('oe_session_intro', $session_data['intro']);
+    }
+    if (!empty($session_data['moderators'])) {
+      $session->set('oe_session_moderators', $session_data['moderators']);
+    }
+    if (!empty($session_data['speakers'])) {
+      $session->set('oe_session_speakers', $session_data['speakers']);
+    }
+    if (!empty($session_data['venue'])) {
+      $session->set('oe_session_venue', $session_data['venue']);
+    }
+    if (!empty($session_data['online_link'])) {
+      $session->set('oe_session_online_link', $session_data['online_link']);
+    }
+    if (!empty($session_data['details'])) {
+      $session->set('oe_session_details', $session_data['details']);
+    }
+    $session->save();
+
+    return $session;
+  }
+
+  /**
+   * Creates nodes and referencing person subentities from a list of names.
+   *
+   * @param string[] $names
+   *   An array of names to be used as names of the persons.
+   *
+   * @return \Drupal\oe_content_sub_entity_person\Entity\PersonInterface[]
+   *   An array of person subentities to be referenced by certain agenda fields.
+   */
+  protected function createPersons(array $names): array {
+    $persons = [];
+    foreach ($names as $name) {
+      $node = Node::create([
+        'type' => 'test_person_bundle',
+        'title' => $name,
+      ]);
+      $persons[] = Person::create([
+        'type' => 'test_person_type',
+        'oe_test_person_reference' => $node,
+      ]);
+    }
+
+    return $persons;
+  }
+
+}

--- a/resources/sass/components/_agenda.scss
+++ b/resources/sass/components/_agenda.scss
@@ -7,11 +7,18 @@
     color: #6c757d !important;
   }
 
-  .bcl-description-list {
-    font-size: 0.875rem;
-  }
+  .session-content {
+    & > div:last-child,
+    .session-details > *:last-child {
+      margin-bottom: 0 !important;
+    }
 
-  .session-details > *:last-child {
-    margin-bottom: 0 !important;
+    .bcl-description-list {
+      font-size: 0.875rem;
+      dl:last-child,
+      dd > div *:last-child {
+        margin-bottom: 0 !important;
+      }
+    }
   }
 }

--- a/resources/sass/components/_agenda.scss
+++ b/resources/sass/components/_agenda.scss
@@ -8,7 +8,7 @@
   }
 
   .session-content {
-    & > div:last-child,
+    & > *:last-child,
     .session-details > *:last-child {
       margin-bottom: 0 !important;
     }

--- a/resources/sass/components/_agenda.scss
+++ b/resources/sass/components/_agenda.scss
@@ -1,0 +1,13 @@
+.oe-agenda {
+  .accordion-button {
+    font-weight: bold;
+  }
+
+  .text-muted {
+    color: #6c757d !important;
+  }
+
+  .bcl-description-list {
+    font-size: 0.875rem;
+  }
+}

--- a/resources/sass/components/_agenda.scss
+++ b/resources/sass/components/_agenda.scss
@@ -10,4 +10,8 @@
   .bcl-description-list {
     font-size: 0.875rem;
   }
+
+  .session-details > *:last-child {
+    margin-bottom: 0 !important;
+  }
 }

--- a/resources/sass/default.style.scss
+++ b/resources/sass/default.style.scss
@@ -5,3 +5,4 @@
 @import "components/list_pages";
 @import "components/patterns";
 @import "components/blocks";
+@import "components/agenda";

--- a/templates/agenda/oe-agenda--oe-default.html.twig
+++ b/templates/agenda/oe-agenda--oe-default.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Theme override to display an agenda entity of oe_default type.
+ *
+ * @see oe_whitelabel_agenda_preprocess_oe_agenda__oe_default()
+ * @see ./modules/contrib/oe_agenda/templates/oe-agenda.html.twig
+ */
+#}
+{{ pattern('accordion', {
+  items: days,
+  attributes: attributes.addClass('oe-agenda'),
+}) }}

--- a/templates/agenda/oe-agenda-day--oe-default.html.twig
+++ b/templates/agenda/oe-agenda-day--oe-default.html.twig
@@ -15,7 +15,7 @@
 {% endif %}
 
 {% for _session in content.oe_day_sessions|field_value %}
-  <div{{ not loop.last ? create_attribute().addClass('mb-4-5') }}>
+  <div{{ not loop.last ? create_attribute({class: ['mb-4-5']}) }}>
     {{ _session }}
   </div>
 {% endfor %}

--- a/templates/agenda/oe-agenda-day--oe-default.html.twig
+++ b/templates/agenda/oe-agenda-day--oe-default.html.twig
@@ -1,0 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override to display an agenda day entity of oe_default type.
+ *
+ * @see ./modules/contrib/oe_agenda/templates/oe-agenda-day.html.twig
+ */
+#}
+{% if not entity.get('title').isEmpty() %}
+  {# Only display the day label as title if the title field is not empty. #}
+  {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
+    title: label,
+    title_tag: 'h3'
+  } only %}
+{% endif %}
+
+{{ content.oe_day_sessions|field_value }}

--- a/templates/agenda/oe-agenda-day--oe-default.html.twig
+++ b/templates/agenda/oe-agenda-day--oe-default.html.twig
@@ -14,4 +14,8 @@
   } only %}
 {% endif %}
 
-{{ content.oe_day_sessions|field_value }}
+{% for _session in content.oe_day_sessions|field_value %}
+  <div{{ not loop.last ? create_attribute().addClass('mb-4-5') }}>
+    {{ _session }}
+  </div>
+{% endfor %}

--- a/templates/agenda/oe-agenda-session--oe-break.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-break.html.twig
@@ -9,14 +9,7 @@
 {% extends "@oe_whitelabel/agenda/oe-agenda-session--oe-default.html.twig" %}
 
 {% block hours %}
-  {{ pattern('icon', {
-    name: 'clock',
-    path: bcl_icon_path,
-    size: 'xs',
-    attributes: create_attribute({
-      class: ['mb-1', 'me-2'],
-    }),
-  }) }}
+  {{ _self.icon() }}
   <span class="text-muted">{{ content.oe_session_hours|field_value }}</span>
 {% endblock %}
 

--- a/templates/agenda/oe-agenda-session--oe-break.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-break.html.twig
@@ -16,5 +16,10 @@
     attributes: create_attribute().addClass('text-muted'),
   } only %}
 
-  {{ content.oe_session_details|field_value }}
+  {# Details. #}
+  {% if not entity.oe_session_details.isEmpty() %}
+    <div class="session-details">
+      {{ content.oe_session_details|field_value }}
+    </div>
+  {% endif %}
 {% endblock %}

--- a/templates/agenda/oe-agenda-session--oe-break.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-break.html.twig
@@ -9,7 +9,7 @@
 {% extends "@oe_whitelabel/agenda/oe-agenda-session--oe-default.html.twig" %}
 
 {% block hours %}
-  {{ _self.icon() }}
+  {{ _self.icon('clock', 'xs', create_attribute().addClass(['mb-1', 'me-2'])) }}
   <span class="text-muted">{{ content.oe_session_hours|field_value }}</span>
 {% endblock %}
 

--- a/templates/agenda/oe-agenda-session--oe-break.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-break.html.twig
@@ -14,17 +14,20 @@
 {% endblock %}
 
 {% block content %}
-  {% set _title = entity.get('name').isEmpty() ? 'Break'|t : label %}
-  {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
-    title: _title,
-    title_tag: 'h4',
-    attributes: create_attribute({class: ['h5', 'mb-4', 'text-muted']}),
-  } only %}
+  {% block title %}
+    {% set _title = entity.get('name').isEmpty() ? 'Break'|t : label %}
+    {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
+      title: _title,
+      title_tag: 'h4',
+      attributes: create_attribute({class: ['h5', 'mb-4', 'text-muted']}),
+    } only %}
+  {% endblock %}
 
-  {# Details. #}
-  {% if not entity.oe_session_details.isEmpty() %}
-    <div class="session-details">
-      {{ content.oe_session_details|field_value }}
-    </div>
-  {% endif %}
+  {% block details %}
+    {% if not entity.oe_session_details.isEmpty() %}
+      <div class="session-details">
+        {{ content.oe_session_details|field_value }}
+      </div>
+    {% endif %}
+  {% endblock %}
 {% endblock %}

--- a/templates/agenda/oe-agenda-session--oe-break.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-break.html.twig
@@ -8,6 +8,18 @@
 #}
 {% extends "@oe_whitelabel/agenda/oe-agenda-session--oe-default.html.twig" %}
 
+{% block hours %}
+  {{ pattern('icon', {
+    name: 'clock',
+    path: bcl_icon_path,
+    size: 'xs',
+    attributes: create_attribute({
+      class: ['mb-1', 'me-2'],
+    }),
+  }) }}
+  <span class="text-muted">{{ content.oe_session_hours|field_value }}</span>
+{% endblock %}
+
 {% block content %}
   {% set _title = entity.get('name').isEmpty() ? 'Break'|t : label %}
   {% include '@oe-bcl/bcl-heading/heading.html.twig' with {

--- a/templates/agenda/oe-agenda-session--oe-break.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-break.html.twig
@@ -13,7 +13,7 @@
   {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
     title: _title,
     title_tag: 'h4',
-    attributes: create_attribute().addClass('text-muted'),
+    attributes: create_attribute().addClass(['h5', 'mb-4', 'text-muted']),
   } only %}
 
   {# Details. #}

--- a/templates/agenda/oe-agenda-session--oe-break.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-break.html.twig
@@ -1,0 +1,20 @@
+{#
+/**
+ * @file
+ * Theme override to display an agenda session entity of oe_break type.
+ *
+ * @see ./modules/contrib/oe_agenda/templates/oe-agenda-session.html.twig
+ */
+#}
+{% extends "@oe_whitelabel/agenda/oe-agenda-session--oe-default.html.twig" %}
+
+{% block content %}
+  {% set _title = entity.get('name').isEmpty() ? 'Break'|t : label %}
+  {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
+    title: _title,
+    title_tag: 'h4',
+    attributes: create_attribute().addClass('text-muted'),
+  } only %}
+
+  {{ content.oe_session_details|field_value }}
+{% endblock %}

--- a/templates/agenda/oe-agenda-session--oe-break.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-break.html.twig
@@ -9,7 +9,7 @@
 {% extends "@oe_whitelabel/agenda/oe-agenda-session--oe-default.html.twig" %}
 
 {% block hours %}
-  {{ _self.icon('clock', 'xs', create_attribute().addClass(['mb-1', 'me-2'])) }}
+  {{ _self.icon('clock', 'xs', create_attribute({class: ['mb-1', 'me-2']})) }}
   <span class="text-muted">{{ content.oe_session_hours|field_value }}</span>
 {% endblock %}
 
@@ -18,7 +18,7 @@
   {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
     title: _title,
     title_tag: 'h4',
-    attributes: create_attribute().addClass(['h5', 'mb-4', 'text-muted']),
+    attributes: create_attribute({class: ['h5', 'mb-4', 'text-muted']}),
   } only %}
 
   {# Details. #}

--- a/templates/agenda/oe-agenda-session--oe-default.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-default.html.twig
@@ -18,7 +18,7 @@
           class: ['mb-1', 'me-2'],
         }),
       }) }}
-      <span class="text-muted">{{ content.oe_session_hours|field_value }}</span>
+      <span>{{ content.oe_session_hours|field_value }}</span>
     {% endblock %}
   </div>
   <div class="session-content col-xxl-10 col-xl-9 col-lg-9">

--- a/templates/agenda/oe-agenda-session--oe-default.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-default.html.twig
@@ -27,7 +27,8 @@
         {# Display session label only if name field is not empty. #}
         {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
           title: label,
-          title_tag: 'h4'
+          title_tag: 'h4',
+          attributes: create_attribute().addClass('h5'),
         } only %}
       {% endif %}
 

--- a/templates/agenda/oe-agenda-session--oe-default.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-default.html.twig
@@ -19,7 +19,7 @@
 <div{{ attributes.addClass('row') }}>
   <div class="col-xxl-2 col-xl-3 col-lg-3 mb-3 mb-lg-0">
     {% block hours %}
-      {{ _self.icon('clock', 'xs', create_attribute().addClass(['mb-1', 'me-2'])) }}
+      {{ _self.icon('clock', 'xs', create_attribute({class: ['mb-1', 'me-2']})) }}
       <span>{{ content.oe_session_hours|field_value }}</span>
     {% endblock %}
   </div>
@@ -30,7 +30,7 @@
         {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
           title: label,
           title_tag: 'h4',
-          attributes: create_attribute().addClass(['h5', 'mb-4-5']),
+          attributes: create_attribute({class: ['h5', 'mb-4-5']}),
         } only %}
       {% endif %}
 

--- a/templates/agenda/oe-agenda-session--oe-default.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-default.html.twig
@@ -21,7 +21,7 @@
       <span class="text-muted">{{ content.oe_session_hours|field_value }}</span>
     {% endblock %}
   </div>
-  <div class="col-xxl-10 col-xl-9 col-lg-9">
+  <div class="session-content col-xxl-10 col-xl-9 col-lg-9">
     {% block content %}
       {% if not entity.get('name').isEmpty() %}
         {# Display session label only if name field is not empty. #}
@@ -62,7 +62,11 @@
       {% endif %}
 
       {# Venue / Online link as description list. #}
-      {{ session_links }}
+      {% if session_links %}
+        <div class="mb-4-5">
+          {{ session_links }}
+        </div>
+      {% endif %}
 
       {# Details. #}
       {% if not entity.oe_session_details.isEmpty() %}

--- a/templates/agenda/oe-agenda-session--oe-default.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-default.html.twig
@@ -28,7 +28,7 @@
         {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
           title: label,
           title_tag: 'h4',
-          attributes: create_attribute().addClass('h5'),
+          attributes: create_attribute().addClass(['h5', 'mb-4-5']),
         } only %}
       {% endif %}
 

--- a/templates/agenda/oe-agenda-session--oe-default.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-default.html.twig
@@ -65,9 +65,11 @@
       {{ session_links }}
 
       {# Details. #}
-      <div class="session-details">
-        {{ content.oe_session_details|field_value }}
-      </div>
+      {% if not entity.oe_session_details.isEmpty() %}
+        <div class="session-details">
+          {{ content.oe_session_details|field_value }}
+        </div>
+      {% endif %}
     {% endblock %}
   </div>
 </div>

--- a/templates/agenda/oe-agenda-session--oe-default.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-default.html.twig
@@ -40,7 +40,7 @@
       {% endif %}
 
       {# Moderators. #}
-      {% if not entity.oe_session_moderators.isEmpty() %}
+      {% if content.oe_session_moderators|field_value is not empty %}
         <div class="mb-4-5">
           {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
             title: content.oe_session_moderators|field_label,
@@ -51,7 +51,7 @@
       {% endif %}
 
       {# Speakers. #}
-      {% if not entity.oe_session_speakers.isEmpty() %}
+      {% if content.oe_session_speakers|field_value is not empty %}
         <div class="mb-4-5">
           {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
             title: content.oe_session_speakers|field_label,

--- a/templates/agenda/oe-agenda-session--oe-default.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-default.html.twig
@@ -1,0 +1,70 @@
+{#
+/**
+ * @file
+ * Theme override to display an agenda session entity of oe_default type.
+ *
+ * @see oe_whitelabel_agenda_preprocess_oe_agenda_session__oe_default()
+ * @see ./modules/contrib/oe_agenda/templates/oe-agenda-session.html.twig
+ */
+#}
+<div{{ attributes.addClass(['row', 'mb-4-5']) }}>
+  <div class="col-xxl-2 col-xl-3 col-lg-3 mb-3 mb-lg-0">
+    {% block hours %}
+      {{ pattern('icon', {
+        name: 'clock',
+        path: bcl_icon_path,
+        size: 'xs',
+        attributes: create_attribute({
+          class: ['mb-1', 'me-2'],
+        }),
+      }) }}
+      <span class="text-muted">{{ content.oe_session_hours|field_value }}</span>
+    {% endblock %}
+  </div>
+  <div class="col-xxl-10 col-xl-9 col-lg-9">
+    {% block content %}
+      {% if not entity.get('name').isEmpty() %}
+        {# Display session label only if name field is not empty. #}
+        {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
+          title: label,
+          title_tag: 'h4'
+        } only %}
+      {% endif %}
+
+      {# Intro. #}
+      {% if not entity.oe_session_intro.isEmpty() %}
+        <div class="mb-4-5">
+          {{ content.oe_session_intro|field_value }}
+        </div>
+      {% endif %}
+
+      {# Moderators. #}
+      {% if not entity.oe_session_moderators.isEmpty() %}
+        <div class="mb-4-5">
+          {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
+            title: content.oe_session_moderators|field_label,
+            title_tag: 'h5',
+          } only %}
+          {{ content.oe_session_moderators|field_value }}
+        </div>
+      {% endif %}
+
+      {# Speakers. #}
+      {% if not entity.oe_session_speakers.isEmpty() %}
+        <div class="mb-4-5">
+          {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
+            title: content.oe_session_speakers|field_label,
+            title_tag: 'h5',
+          } only %}
+          {{ content.oe_session_speakers|field_value }}
+        </div>
+      {% endif %}
+
+      {# Venue / Online link as description list. #}
+      {{ session_links }}
+
+      {# Details. #}
+      {{ content.oe_session_details|field_value }}
+    {% endblock %}
+  </div>
+</div>

--- a/templates/agenda/oe-agenda-session--oe-default.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-default.html.twig
@@ -7,19 +7,19 @@
  * @see ./modules/contrib/oe_agenda/templates/oe-agenda-session.html.twig
  */
 #}
-{% macro icon(name = 'clock', size = 'xs', attributes) %}
+{% macro icon(name, size, attributes) %}
   {{ pattern('icon', {
     name: name,
     path: bcl_icon_path,
     size: size,
-    attributes: attributes|default(create_attribute().addClass(['mb-1', 'me-2']))
+    attributes: attributes,
   }) }}
 {% endmacro %}
 
 <div{{ attributes.addClass('row') }}>
   <div class="col-xxl-2 col-xl-3 col-lg-3 mb-3 mb-lg-0">
     {% block hours %}
-      {{ _self.icon() }}
+      {{ _self.icon('clock', 'xs', create_attribute().addClass(['mb-1', 'me-2'])) }}
       <span>{{ content.oe_session_hours|field_value }}</span>
     {% endblock %}
   </div>

--- a/templates/agenda/oe-agenda-session--oe-default.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-default.html.twig
@@ -48,7 +48,11 @@
             title: content.oe_session_moderators|field_label,
             title_tag: 'h5',
           } only %}
-          {{ content.oe_session_moderators|field_value }}
+          {% for _moderator in content.oe_session_moderators|field_value %}
+            <div{{ not loop.last ? create_attribute({class: ['mb-2']}) }}>
+              {{ _moderator }}
+            </div>
+          {% endfor %}
         </div>
       {% endif %}
 
@@ -59,7 +63,11 @@
             title: content.oe_session_speakers|field_label,
             title_tag: 'h5',
           } only %}
-          {{ content.oe_session_speakers|field_value }}
+          {% for _speaker in content.oe_session_speakers|field_value %}
+            <div{{ not loop.last ? create_attribute({class: ['mb-3']}) }}>
+              {{ _speaker }}
+            </div>
+          {% endfor %}
         </div>
       {% endif %}
 

--- a/templates/agenda/oe-agenda-session--oe-default.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-default.html.twig
@@ -64,7 +64,9 @@
       {{ session_links }}
 
       {# Details. #}
-      {{ content.oe_session_details|field_value }}
+      <div class="session-details">
+        {{ content.oe_session_details|field_value }}
+      </div>
     {% endblock %}
   </div>
 </div>

--- a/templates/agenda/oe-agenda-session--oe-default.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-default.html.twig
@@ -7,17 +7,19 @@
  * @see ./modules/contrib/oe_agenda/templates/oe-agenda-session.html.twig
  */
 #}
+{% macro icon(name = 'clock', size = 'xs', attributes) %}
+  {{ pattern('icon', {
+    name: name,
+    path: bcl_icon_path,
+    size: size,
+    attributes: attributes|default(create_attribute().addClass(['mb-1', 'me-2']))
+  }) }}
+{% endmacro %}
+
 <div{{ attributes.addClass('row') }}>
   <div class="col-xxl-2 col-xl-3 col-lg-3 mb-3 mb-lg-0">
     {% block hours %}
-      {{ pattern('icon', {
-        name: 'clock',
-        path: bcl_icon_path,
-        size: 'xs',
-        attributes: create_attribute({
-          class: ['mb-1', 'me-2'],
-        }),
-      }) }}
+      {{ _self.icon() }}
       <span>{{ content.oe_session_hours|field_value }}</span>
     {% endblock %}
   </div>

--- a/templates/agenda/oe-agenda-session--oe-default.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-default.html.twig
@@ -25,65 +25,71 @@
   </div>
   <div class="session-content col-xxl-10 col-xl-9 col-lg-9">
     {% block content %}
-      {% if not entity.get('name').isEmpty() %}
-        {# Display session label only if name field is not empty. #}
-        {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
-          title: label,
-          title_tag: 'h4',
-          attributes: create_attribute({class: ['h5', 'mb-4-5']}),
-        } only %}
-      {% endif %}
-
-      {# Intro. #}
-      {% if not entity.oe_session_intro.isEmpty() %}
-        <div class="mb-4-5">
-          {{ content.oe_session_intro|field_value }}
-        </div>
-      {% endif %}
-
-      {# Moderators. #}
-      {% if content.oe_session_moderators|field_value is not empty %}
-        <div class="mb-4-5">
+      {% block title %}
+        {% if not entity.get('name').isEmpty() %}
           {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
-            title: content.oe_session_moderators|field_label,
-            title_tag: 'h5',
+            title: label,
+            title_tag: 'h4',
+            attributes: create_attribute({class: ['h5', 'mb-4-5']}),
           } only %}
-          {% for _moderator in content.oe_session_moderators|field_value %}
-            <div{{ not loop.last ? create_attribute({class: ['mb-2']}) }}>
-              {{ _moderator }}
-            </div>
-          {% endfor %}
-        </div>
-      {% endif %}
+        {% endif %}
+      {% endblock %}
 
-      {# Speakers. #}
-      {% if content.oe_session_speakers|field_value is not empty %}
-        <div class="mb-4-5">
-          {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
-            title: content.oe_session_speakers|field_label,
-            title_tag: 'h5',
-          } only %}
-          {% for _speaker in content.oe_session_speakers|field_value %}
-            <div{{ not loop.last ? create_attribute({class: ['mb-3']}) }}>
-              {{ _speaker }}
-            </div>
-          {% endfor %}
-        </div>
-      {% endif %}
+      {% block intro %}
+        {% if not entity.oe_session_intro.isEmpty() %}
+          <div class="mb-4-5">
+            {{ content.oe_session_intro|field_value }}
+          </div>
+        {% endif %}
+      {% endblock %}
 
-      {# Venue / Online link as description list. #}
-      {% if session_links %}
-        <div class="mb-4-5">
-          {{ session_links }}
-        </div>
-      {% endif %}
+      {% block moderators %}
+        {% if content.oe_session_moderators|field_value is not empty %}
+          <div class="mb-4-5">
+            {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
+              title: content.oe_session_moderators|field_label,
+              title_tag: 'h5',
+            } only %}
+            {% for _moderator in content.oe_session_moderators|field_value %}
+              <div{{ not loop.last ? create_attribute({class: ['mb-2']}) }}>
+                {{ _moderator }}
+              </div>
+            {% endfor %}
+          </div>
+        {% endif %}
+      {% endblock %}
 
-      {# Details. #}
-      {% if not entity.oe_session_details.isEmpty() %}
-        <div class="session-details">
-          {{ content.oe_session_details|field_value }}
-        </div>
-      {% endif %}
+      {% block speakers %}
+        {% if content.oe_session_speakers|field_value is not empty %}
+          <div class="mb-4-5">
+            {% include '@oe-bcl/bcl-heading/heading.html.twig' with {
+              title: content.oe_session_speakers|field_label,
+              title_tag: 'h5',
+            } only %}
+            {% for _speaker in content.oe_session_speakers|field_value %}
+              <div{{ not loop.last ? create_attribute({class: ['mb-3']}) }}>
+                {{ _speaker }}
+              </div>
+            {% endfor %}
+          </div>
+        {% endif %}
+      {% endblock %}
+
+      {% block links %}
+        {% if session_links %}
+          <div class="mb-4-5">
+            {{ session_links }}
+          </div>
+        {% endif %}
+      {% endblock %}
+
+      {% block details %}
+        {% if not entity.oe_session_details.isEmpty() %}
+          <div class="session-details">
+            {{ content.oe_session_details|field_value }}
+          </div>
+        {% endif %}
+      {% endblock %}
     {% endblock %}
   </div>
 </div>

--- a/templates/agenda/oe-agenda-session--oe-default.html.twig
+++ b/templates/agenda/oe-agenda-session--oe-default.html.twig
@@ -7,7 +7,7 @@
  * @see ./modules/contrib/oe_agenda/templates/oe-agenda-session.html.twig
  */
 #}
-<div{{ attributes.addClass(['row', 'mb-4-5']) }}>
+<div{{ attributes.addClass('row') }}>
   <div class="col-xxl-2 col-xl-3 col-lg-3 mb-3 mb-lg-0">
     {% block hours %}
       {{ pattern('icon', {


### PR DESCRIPTION
Hi @brummbar,

The PR is still wip, without tests. There are some changes since we last discussed, most importanty that I ended up adding templates/preprocesses only for the bundles that are shipped by oe_agenda, and I don't override the general entity templates. I think it's cleaner like this, because we use bundle fields in all the templates. 

This affected the session templates a bit, so now I don't have a `oe-agenda-session.html.twig` that the `oe-default` and `oe-break` templates are extending, instead the `oe-break` template extends the `oe-default` (but otherwise the idea is the same). Let me know what you think, I will add comments to the code where I have something to say.