### PR TITLE
EPHEH-465: Refactor color scheme injection.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "drupal/daterange_compact": "^2.0.1",
         "drupal/twig_field_value": "^2.0.2",
         "openeuropa/composer-artifacts": "^1.0.0-alpha1",
-        "openeuropa/oe_bootstrap_theme": "^1.10.0"
+        "openeuropa/oe_bootstrap_theme": "0.318.202406072027"
     },
     "require-dev": {
         "composer/installers": "^1.11",
@@ -78,7 +78,7 @@
         "enable-patching": true,
         "patches": {
             "openeuropa/oe_bootstrap_theme": {
-                "development": "https://github.com/openeuropa/oe_bootstrap_theme/compare/1.10.0...1.x.diff"
+                "development": "https://github.com/openeuropa/oe_bootstrap_theme/compare/0.318.202406072027...1.x.diff"
             }
         },
         "artifacts": {
@@ -110,12 +110,7 @@
         },
         "_readme": [
             "Explicit requirement of nikic/php-parser ^4 as later versions are not compatible with grumphp @see https://github.com/phpro/grumphp/issues/1119"
-        ],
-        "patches": {
-            "openeuropa/oe_bootstrap_theme": {
-                "Color scheme development": "https://github.com/openeuropa/oe_bootstrap_theme/compare/1.x...contribution/EPHEH-318.diff"
-            }
-        }
+        ]
     },
     "config": {
         "sort-packages": true,

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "drupal/daterange_compact": "^2.0.1",
         "drupal/twig_field_value": "^2.0.2",
         "openeuropa/composer-artifacts": "^1.0.0-alpha1",
-        "openeuropa/oe_bootstrap_theme": "0.318.202406072027"
+        "openeuropa/oe_bootstrap_theme": "0.318.202406121551"
     },
     "require-dev": {
         "composer/installers": "^1.11",
@@ -76,11 +76,6 @@
     "extra": {
         "composer-exit-on-patch-failure": true,
         "enable-patching": true,
-        "patches": {
-            "openeuropa/oe_bootstrap_theme": {
-                "development": "https://github.com/openeuropa/oe_bootstrap_theme/compare/0.318.202406072027...1.x.diff"
-            }
-        },
         "artifacts": {
             "openeuropa/oe_bootstrap_theme": {
                 "dist": {

--- a/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
+++ b/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
@@ -522,10 +522,6 @@ function oe_whitelabel_preprocess_paragraph__oe_facts_figures(array &$variables)
  * Implements hook_preprocess_paragraph() for oe_carousel paragraph.
  */
 function oe_whitelabel_preprocess_paragraph__oe_carousel(array &$variables): void {
-  /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
-  $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables);
-
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
   $variables['items'] = [];
@@ -686,10 +682,6 @@ function oe_whitelabel_paragraphs_preprocess_paragraph__oe_gallery(&$variables) 
   // title tag, we set it up here so that further preprocess hooks can change
   // it.
   $variables['title_tag'] = 'h2';
-
-  /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
-  $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables);
 }
 
 /**

--- a/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
+++ b/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
@@ -68,6 +68,10 @@ function oe_whitelabel_paragraphs_theme_suggestions_field_alter(array &$suggesti
  * Implements hook_preprocess_paragraph().
  */
 function oe_whitelabel_preprocess_paragraph__oe_links_block(array &$variables): void {
+  /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
+  $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
+  $color_scheme_preprocess->injectColorScheme($variables, FALSE);
+
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
   $variables['orientation'] = $paragraph->get('oe_w_links_block_orientation')->value;

--- a/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
+++ b/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
@@ -70,7 +70,7 @@ function oe_whitelabel_paragraphs_theme_suggestions_field_alter(array &$suggesti
 function oe_whitelabel_preprocess_paragraph__oe_links_block(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables, FALSE);
+  $color_scheme_preprocess->injectColorScheme($variables);
 
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
@@ -125,7 +125,7 @@ function oe_whitelabel_preprocess_paragraph__oe_social_media_follow(array &$vari
 function oe_whitelabel_preprocess_paragraph__oe_accordion(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables, FALSE);
+  $color_scheme_preprocess->injectColorScheme($variables);
 
   // Massage data to be compliant with OE Bootstrap Theme accordion pattern
   // data structure.
@@ -207,7 +207,7 @@ function oe_whitelabel_preprocess_paragraph__oe_av_media(array &$variables): voi
 function oe_whitelabel_preprocess_paragraph__oe_list_item_block(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables, FALSE);
+  $color_scheme_preprocess->injectColorScheme($variables);
 
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
@@ -276,12 +276,19 @@ function oe_whitelabel_preprocess_paragraph__oe_banner(array &$variables): void 
   $variant = $paragraph->get('oe_paragraphs_variant')->value ?? 'default';
   $variables['variant'] = str_replace('oe_banner_', '', $variant);
 
-  if ($variables['variant'] === 'default') {
-    $color_scheme_preprocess->injectColorScheme($variables);
-  }
-  else {
-    $color_scheme_preprocess->injectColorScheme($variables, FALSE);
-  }
+  match($variables['variant']) {
+    'image' => $color_scheme_preprocess->injectColorScheme($variables, [
+      'text_colored' => TRUE,
+    ]),
+    'image_shade' => $color_scheme_preprocess->injectColorScheme($variables, []),
+    'primary' => $color_scheme_preprocess->injectColorScheme($variables, [
+      'primary_background' => TRUE,
+    ]),
+    default => $color_scheme_preprocess->injectColorScheme($variables, [
+      'background' => TRUE,
+      'text_colored' => TRUE,
+    ]),
+  };
 
   $variables['title'] = $paragraph->get('field_oe_title')->value;
   $variables['description'] = $paragraph->get('field_oe_text')->value;
@@ -375,7 +382,7 @@ function oe_whitelabel_preprocess_paragraph__oe_banner(array &$variables): void 
 function oe_whitelabel_preprocess_paragraph__oe_timeline(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables, FALSE);
+  $color_scheme_preprocess->injectColorScheme($variables);
 
   $paragraph = $variables['paragraph'];
   if (!$paragraph->get('field_oe_title')->isEmpty()) {
@@ -443,7 +450,9 @@ function oe_whitelabel_preprocess_paragraph__oe_content_row__variant_inpage_navi
 function oe_whitelabel_preprocess_paragraph__oe_description_list(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables);
+  $color_scheme_preprocess->injectColorScheme($variables, [
+    'background' => TRUE,
+  ]);
 
   /** @var Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
@@ -474,7 +483,7 @@ function oe_whitelabel_preprocess_paragraph__oe_description_list(array &$variabl
 function oe_whitelabel_preprocess_paragraph__oe_facts_figures(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables, FALSE);
+  $color_scheme_preprocess->injectColorScheme($variables);
 
   /** @var \Drupal\paragraphs\ParagraphInterface $paragraph */
   $paragraph = $variables['paragraph'];
@@ -517,7 +526,7 @@ function oe_whitelabel_preprocess_paragraph__oe_facts_figures(array &$variables)
 function oe_whitelabel_preprocess_paragraph__oe_carousel(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables, FALSE);
+  $color_scheme_preprocess->injectColorScheme($variables);
 
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
@@ -682,7 +691,7 @@ function oe_whitelabel_paragraphs_preprocess_paragraph__oe_gallery(&$variables) 
 
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables, FALSE);
+  $color_scheme_preprocess->injectColorScheme($variables);
 }
 
 /**
@@ -754,7 +763,7 @@ function _oe_whitelabel_paragraphs_preprocess_paragraph_media(array &$variables)
 function oe_whitelabel_paragraphs_preprocess_paragraph__oe_document(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables, FALSE);
+  $color_scheme_preprocess->injectColorScheme($variables);
 }
 
 /**
@@ -763,5 +772,7 @@ function oe_whitelabel_paragraphs_preprocess_paragraph__oe_document(array &$vari
 function oe_whitelabel_paragraphs_preprocess_paragraph__oe_quote(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables);
+  $color_scheme_preprocess->injectColorScheme($variables, [
+    'background' => TRUE,
+  ]);
 }

--- a/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
+++ b/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
@@ -70,7 +70,9 @@ function oe_whitelabel_paragraphs_theme_suggestions_field_alter(array &$suggesti
 function oe_whitelabel_preprocess_paragraph__oe_links_block(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables);
+  $color_scheme_preprocess->injectColorScheme($variables, [
+    'text_colored' => TRUE,
+  ]);
 
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
@@ -125,7 +127,9 @@ function oe_whitelabel_preprocess_paragraph__oe_social_media_follow(array &$vari
 function oe_whitelabel_preprocess_paragraph__oe_accordion(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables);
+  $color_scheme_preprocess->injectColorScheme($variables, [
+    'text_colored' => TRUE,
+  ]);
 
   // Massage data to be compliant with OE Bootstrap Theme accordion pattern
   // data structure.
@@ -207,7 +211,9 @@ function oe_whitelabel_preprocess_paragraph__oe_av_media(array &$variables): voi
 function oe_whitelabel_preprocess_paragraph__oe_list_item_block(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables);
+  $color_scheme_preprocess->injectColorScheme($variables, [
+    'text_colored' => TRUE,
+  ]);
 
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
@@ -280,7 +286,7 @@ function oe_whitelabel_preprocess_paragraph__oe_banner(array &$variables): void 
     'image' => $color_scheme_preprocess->injectColorScheme($variables, [
       'text_colored' => TRUE,
     ]),
-    'image_shade' => $color_scheme_preprocess->injectColorScheme($variables, []),
+    'image_shade' => $color_scheme_preprocess->injectColorScheme($variables),
     'primary' => $color_scheme_preprocess->injectColorScheme($variables, [
       'primary_background' => TRUE,
     ]),
@@ -382,7 +388,9 @@ function oe_whitelabel_preprocess_paragraph__oe_banner(array &$variables): void 
 function oe_whitelabel_preprocess_paragraph__oe_timeline(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables);
+  $color_scheme_preprocess->injectColorScheme($variables, [
+    'text_colored' => TRUE,
+  ]);
 
   $paragraph = $variables['paragraph'];
   if (!$paragraph->get('field_oe_title')->isEmpty()) {
@@ -450,7 +458,9 @@ function oe_whitelabel_preprocess_paragraph__oe_content_row__variant_inpage_navi
 function oe_whitelabel_preprocess_paragraph__oe_description_list(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables);
+  $color_scheme_preprocess->injectColorScheme($variables, [
+    'text_colored' => TRUE,
+  ]);
 
   /** @var Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
@@ -481,7 +491,9 @@ function oe_whitelabel_preprocess_paragraph__oe_description_list(array &$variabl
 function oe_whitelabel_preprocess_paragraph__oe_facts_figures(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables);
+  $color_scheme_preprocess->injectColorScheme($variables, [
+    'text_colored' => TRUE,
+  ]);
 
   /** @var \Drupal\paragraphs\ParagraphInterface $paragraph */
   $paragraph = $variables['paragraph'];
@@ -753,7 +765,9 @@ function _oe_whitelabel_paragraphs_preprocess_paragraph_media(array &$variables)
 function oe_whitelabel_paragraphs_preprocess_paragraph__oe_document(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables);
+  $color_scheme_preprocess->injectColorScheme($variables, [
+    'text_colored' => TRUE,
+  ]);
 }
 
 /**
@@ -764,5 +778,6 @@ function oe_whitelabel_paragraphs_preprocess_paragraph__oe_quote(array &$variabl
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
   $color_scheme_preprocess->injectColorScheme($variables, [
     'background' => TRUE,
+    'text_colored' => TRUE,
   ]);
 }

--- a/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
+++ b/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
@@ -450,9 +450,7 @@ function oe_whitelabel_preprocess_paragraph__oe_content_row__variant_inpage_navi
 function oe_whitelabel_preprocess_paragraph__oe_description_list(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables, [
-    'background' => TRUE,
-  ]);
+  $color_scheme_preprocess->injectColorScheme($variables);
 
   /** @var Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];

--- a/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
+++ b/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
@@ -150,10 +150,6 @@ function oe_whitelabel_preprocess_paragraph__oe_accordion(array &$variables): vo
  * Implements hook_preprocess_paragraph() for paragraph--oe-text-feature-media.html.twig.
  */
 function oe_whitelabel_preprocess_paragraph__oe_text_feature_media(array &$variables): void {
-  /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
-  $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables);
-
   /** @var \Drupal\paragraphs\Entity\Paragraph $paragraph */
   $paragraph = $variables['paragraph'];
 

--- a/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
+++ b/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
@@ -125,7 +125,7 @@ function oe_whitelabel_preprocess_paragraph__oe_social_media_follow(array &$vari
 function oe_whitelabel_preprocess_paragraph__oe_accordion(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables);
+  $color_scheme_preprocess->injectColorScheme($variables, FALSE);
 
   // Massage data to be compliant with OE Bootstrap Theme accordion pattern
   // data structure.
@@ -375,7 +375,7 @@ function oe_whitelabel_preprocess_paragraph__oe_banner(array &$variables): void 
 function oe_whitelabel_preprocess_paragraph__oe_timeline(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables);
+  $color_scheme_preprocess->injectColorScheme($variables, FALSE);
 
   $paragraph = $variables['paragraph'];
   if (!$paragraph->get('field_oe_title')->isEmpty()) {
@@ -474,7 +474,7 @@ function oe_whitelabel_preprocess_paragraph__oe_description_list(array &$variabl
 function oe_whitelabel_preprocess_paragraph__oe_facts_figures(array &$variables): void {
   /** @var \Drupal\oe_whitelabel\ColorSchemePreprocess $color_scheme_preprocess */
   $color_scheme_preprocess = \Drupal::classResolver(ColorSchemePreprocess::class);
-  $color_scheme_preprocess->injectColorScheme($variables);
+  $color_scheme_preprocess->injectColorScheme($variables, FALSE);
 
   /** @var \Drupal\paragraphs\ParagraphInterface $paragraph */
   $paragraph = $variables['paragraph'];

--- a/modules/oe_whitelabel_paragraphs/tests/src/Kernel/Paragraphs/ColorSchemeTest.php
+++ b/modules/oe_whitelabel_paragraphs/tests/src/Kernel/Paragraphs/ColorSchemeTest.php
@@ -79,10 +79,8 @@ class ColorSchemeTest extends ParagraphsTestBase {
       $html = $this->renderParagraph($paragraph);
       $crawler = new Crawler($html);
 
-      $element = $crawler->filter($data['wrapper_selector'] . '.foo-bar.text-color-default');
+      $element = $crawler->filter($data['wrapper_selector'] . '.foo-bar');
       $this->assertCount(1, $element, sprintf('Element "%s" has color scheme applied.', $data['wrapper_selector']));
-      $has_background = (bool) $crawler->filter('.bg-default')->count();
-      $this->assertTrue($data['has_background'] === $has_background, sprintf('Element "%s" does not have ".bg-default" class.', $data['wrapper_selector']));
     }
   }
 
@@ -103,22 +101,7 @@ class ColorSchemeTest extends ParagraphsTestBase {
           'field_oe_text_long' => 'Accordion text',
         ]),
       ],
-      'wrapper_selector' => '.accordion',
-      'has_background' => TRUE,
-    ];
-    yield [
-      'values' => [
-        'type' => 'oe_carousel',
-      ],
-      'wrapper_selector' => '.carousel',
-      'has_background' => FALSE,
-    ];
-    yield [
-      'values' => [
-        'type' => 'oe_gallery',
-      ],
-      'wrapper_selector' => '.paragraph--type--oe-gallery',
-      'has_background' => FALSE,
+      'wrapper_selector' => '.accordion.text-color-default',
     ];
     yield [
       'values' => [
@@ -126,8 +109,7 @@ class ColorSchemeTest extends ParagraphsTestBase {
         'oe_paragraphs_variant' => 'default',
         'field_oe_title' => 'Banner',
       ],
-      'wrapper_selector' => '.bcl-banner',
-      'has_background' => TRUE,
+      'wrapper_selector' => '.bcl-banner.text-color-default',
     ];
     yield [
       'values' => [
@@ -135,8 +117,7 @@ class ColorSchemeTest extends ParagraphsTestBase {
         'oe_paragraphs_variant' => 'oe_banner_image',
         'field_oe_title' => 'Banner',
       ],
-      'wrapper_selector' => '.bcl-banner',
-      'has_background' => FALSE,
+      'wrapper_selector' => '.bcl-banner.text-color-default',
     ];
     yield [
       'values' => [
@@ -145,7 +126,6 @@ class ColorSchemeTest extends ParagraphsTestBase {
         'field_oe_title' => 'Banner',
       ],
       'wrapper_selector' => '.bcl-banner',
-      'has_background' => FALSE,
     ];
     yield [
       'values' => [
@@ -153,8 +133,7 @@ class ColorSchemeTest extends ParagraphsTestBase {
         'oe_paragraphs_variant' => 'oe_banner_primary',
         'field_oe_title' => 'Banner',
       ],
-      'wrapper_selector' => '.bcl-banner',
-      'has_background' => FALSE,
+      'wrapper_selector' => '.bcl-banner.text-bg-primary',
     ];
     yield [
       'values' => [
@@ -162,8 +141,7 @@ class ColorSchemeTest extends ParagraphsTestBase {
         'field_oe_text' => 'This is a test quote',
         'field_oe_plain_text_long' => 'Quote text',
       ],
-      'wrapper_selector' => 'figure',
-      'has_background' => TRUE,
+      'wrapper_selector' => 'figure.bg-default.text-color-default',
     ];
     yield [
       'values' => [
@@ -177,15 +155,13 @@ class ColorSchemeTest extends ParagraphsTestBase {
           ],
         ],
       ],
-      'wrapper_selector' => '.bcl-description-list',
-      'has_background' => TRUE,
+      'wrapper_selector' => '.bcl-description-list.text-color-default',
     ];
     yield [
       'values' => [
         'type' => 'oe_document',
       ],
-      'wrapper_selector' => '.paragraph--type--oe-document',
-      'has_background' => FALSE,
+      'wrapper_selector' => '.paragraph--type--oe-document.text-color-default',
     ];
     yield [
       'values' => [
@@ -196,8 +172,7 @@ class ColorSchemeTest extends ParagraphsTestBase {
           'title' => 'Read more',
         ],
       ],
-      'wrapper_selector' => '.bcl-fact-figures',
-      'has_background' => TRUE,
+      'wrapper_selector' => '.bcl-fact-figures.text-color-default',
     ];
     yield [
       'values' => [
@@ -206,17 +181,16 @@ class ColorSchemeTest extends ParagraphsTestBase {
         'field_oe_list_item_block_layout' => 'one_column',
         'field_oe_title' => 'Listing item block title',
       ],
-      'wrapper_selector' => '.bcl-listing',
-      'has_background' => FALSE,
+      'wrapper_selector' => '.bcl-listing.text-color-default',
     ];
     yield [
       'values' => [
-        'type' => 'oe_text_feature_media',
-        'field_oe_title' => 'Title',
-        'field_oe_plain_text_long' => 'Text',
+        'type' => 'oe_links_block',
+        'field_oe_text' => 'Info',
+        'oe_bt_links_block_orientation' => 'vertical',
+        'oe_bt_links_block_background' => 'gray',
       ],
-      'wrapper_selector' => '.bcl-featured-media',
-      'has_background' => TRUE,
+      'wrapper_selector' => '.bcl-links-block.text-color-default',
     ];
     yield [
       'values' => [
@@ -230,8 +204,7 @@ class ColorSchemeTest extends ParagraphsTestBase {
           ],
         ],
       ],
-      'wrapper_selector' => '.bcl-timeline',
-      'has_background' => TRUE,
+      'wrapper_selector' => '.bcl-timeline.text-color-default',
     ];
   }
 

--- a/src/ColorSchemePreprocess.php
+++ b/src/ColorSchemePreprocess.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\oe_whitelabel;
 
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Template\Attribute;
 
 /**
  * Class containing color scheme preprocesses.
@@ -19,16 +20,26 @@ class ColorSchemePreprocess {
    * @param bool $background
    *   Add a background class if TRUE.
    */
-  public function injectColorScheme(array &$variables, bool $background = TRUE): void {
+  public function injectColorScheme(array &$variables, array $options = []): void {
     if (!isset($variables['elements']['#oe_color_scheme'])) {
       return;
     }
 
-    $variables['attributes']['class'][] = Html::getClass($variables['elements']['#oe_color_scheme']);
-    $variables['attributes']['class'][] = 'text-color-default';
+    $variables['attributes'] = new Attribute($variables['attributes'] ?? []);
+    $variables['attributes']->addClass(Html::getClass($variables['elements']['#oe_color_scheme']));
 
-    if ($background) {
-      $variables['attributes']['class'][] = 'bg-default';
+    if ($options['text_colored']) {
+      $variables['attributes']->addClass('text-color-default');
+    }
+
+    if ($options['background']) {
+      $variables['attributes']->addClass('bg-default');
+    }
+
+    if ($options['primary_background']) {
+      $variables['attributes']->addClass('text-bg-primary');
+      // The text-bg- class already sets the text and background color.
+      $variables['attributes']->removeClass(['bg-default', 'text-color-default']);
     }
   }
 

--- a/src/ColorSchemePreprocess.php
+++ b/src/ColorSchemePreprocess.php
@@ -32,41 +32,58 @@ class ColorSchemePreprocess {
    *     the background and text color to danger.
    *   - 'success_background': (bool) If set to TRUE, adds a class to override
    *     the background and text color to success.
+   *
+   * @SuppressWarnings(PHPMD.NPathComplexity)
    */
   public function injectColorScheme(array &$variables, array $options = []): void {
     if (!isset($variables['elements']['#oe_color_scheme'])) {
       return;
     }
 
+    $default_options = [
+      'text_colored' => FALSE,
+      'background' => FALSE,
+      'primary_background' => FALSE,
+      'secondary_background' => FALSE,
+      'danger_background' => FALSE,
+      'success_background' => FALSE,
+    ];
+
+    if (array_diff_key($options, $default_options)) {
+      throw new \InvalidArgumentException('Invalid options provided.');
+    }
+
+    $options = $options + $default_options;
+
     $variables['attributes'] = new Attribute($variables['attributes'] ?? []);
     $variables['attributes']->addClass(Html::getClass($variables['elements']['#oe_color_scheme']));
 
-    if (!empty($options['text_colored'])) {
+    if ($options['text_colored'] === TRUE) {
       $variables['attributes']->addClass('text-color-default');
     }
 
-    if (!empty($options['background'])) {
+    if ($options['background'] === TRUE) {
       $variables['attributes']->addClass('bg-default');
     }
 
     // The text-bg- classes already set the text and background color,
     // so we remove the others.
-    if (!empty($options['primary_background'])) {
+    if ($options['primary_background'] === TRUE) {
       $variables['attributes']->addClass('text-bg-primary');
       $variables['attributes']->removeClass(['bg-default', 'text-color-default']);
     }
 
-    if (!empty($options['secondary_background'])) {
+    if ($options['secondary_background'] === TRUE) {
       $variables['attributes']->addClass('text-bg-secondary');
       $variables['attributes']->removeClass(['bg-default', 'text-color-default']);
     }
 
-    if (!empty($options['danger_background'])) {
+    if ($options['danger_background'] === TRUE) {
       $variables['attributes']->addClass('text-bg-danger');
       $variables['attributes']->removeClass(['bg-default', 'text-color-default']);
     }
 
-    if (!empty($options['success_background'])) {
+    if ($options['success_background'] === TRUE) {
       $variables['attributes']->addClass('text-bg-success');
       $variables['attributes']->removeClass(['bg-default', 'text-color-default']);
     }

--- a/src/ColorSchemePreprocess.php
+++ b/src/ColorSchemePreprocess.php
@@ -50,7 +50,7 @@ class ColorSchemePreprocess {
     }
 
     // The text-bg- classes already set the text and background color,
-    //  so we remove the others.
+    // so we remove the others.
     if ($options['primary_background']) {
       $variables['attributes']->addClass('text-bg-primary');
       $variables['attributes']->removeClass(['bg-default', 'text-color-default']);

--- a/src/ColorSchemePreprocess.php
+++ b/src/ColorSchemePreprocess.php
@@ -41,32 +41,32 @@ class ColorSchemePreprocess {
     $variables['attributes'] = new Attribute($variables['attributes'] ?? []);
     $variables['attributes']->addClass(Html::getClass($variables['elements']['#oe_color_scheme']));
 
-    if ($options['text_colored']) {
+    if (!empty($options['text_colored'])) {
       $variables['attributes']->addClass('text-color-default');
     }
 
-    if ($options['background']) {
+    if (!empty($options['background'])) {
       $variables['attributes']->addClass('bg-default');
     }
 
     // The text-bg- classes already set the text and background color,
     // so we remove the others.
-    if ($options['primary_background']) {
+    if (!empty($options['primary_background'])) {
       $variables['attributes']->addClass('text-bg-primary');
       $variables['attributes']->removeClass(['bg-default', 'text-color-default']);
     }
 
-    if ($options['secondary_background']) {
+    if (!empty($options['secondary_background'])) {
       $variables['attributes']->addClass('text-bg-secondary');
       $variables['attributes']->removeClass(['bg-default', 'text-color-default']);
     }
 
-    if ($options['danger_background']) {
+    if (!empty($options['danger_background'])) {
       $variables['attributes']->addClass('text-bg-danger');
       $variables['attributes']->removeClass(['bg-default', 'text-color-default']);
     }
 
-    if ($options['success_background']) {
+    if (!empty($options['success_background'])) {
       $variables['attributes']->addClass('text-bg-success');
       $variables['attributes']->removeClass(['bg-default', 'text-color-default']);
     }

--- a/src/ColorSchemePreprocess.php
+++ b/src/ColorSchemePreprocess.php
@@ -17,8 +17,21 @@ class ColorSchemePreprocess {
    *
    * @param array $variables
    *   The render array.
-   * @param bool $background
-   *   Add a background class if TRUE.
+   * @param array $options
+   *   An associative array of options to control the behavior of the function.
+   *   Possible keys are:
+   *   - 'text_colored': (bool) If set to TRUE, adds a class to override the
+   *     text color.
+   *   - 'background': (bool) If set to TRUE, adds a class to override the
+   *     background color.
+   *   - 'primary_background': (bool) If set to TRUE, adds a class to override
+   *     the background and text color to primary.
+   *   - 'secondary_background': (bool) If set to TRUE, adds a class to override
+   *     the background and text color to secondary.
+   *   - 'danger_background': (bool) If set to TRUE, adds a class to override
+   *     the background and text color to danger.
+   *   - 'success_background': (bool) If set to TRUE, adds a class to override
+   *     the background and text color to success.
    */
   public function injectColorScheme(array &$variables, array $options = []): void {
     if (!isset($variables['elements']['#oe_color_scheme'])) {
@@ -36,9 +49,25 @@ class ColorSchemePreprocess {
       $variables['attributes']->addClass('bg-default');
     }
 
+    // The text-bg- classes already set the text and background color,
+    //  so we remove the others.
     if ($options['primary_background']) {
       $variables['attributes']->addClass('text-bg-primary');
-      // The text-bg- class already sets the text and background color.
+      $variables['attributes']->removeClass(['bg-default', 'text-color-default']);
+    }
+
+    if ($options['secondary_background']) {
+      $variables['attributes']->addClass('text-bg-secondary');
+      $variables['attributes']->removeClass(['bg-default', 'text-color-default']);
+    }
+
+    if ($options['danger_background']) {
+      $variables['attributes']->addClass('text-bg-danger');
+      $variables['attributes']->removeClass(['bg-default', 'text-color-default']);
+    }
+
+    if ($options['success_background']) {
+      $variables['attributes']->addClass('text-bg-success');
       $variables['attributes']->removeClass(['bg-default', 'text-color-default']);
     }
   }


### PR DESCRIPTION
After the showcase in figma, it became clear that just background parameter would not be sufficient as the banner variants need diferent combinations of classes from the new color scheme api.