### PR TITLE
OEL-3916: Paragraph oe_accordion was ignoring field display settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ docker-compose exec web ./vendor/bin/run toolkit:code-review
 
 #### Run phpunit tests
 
-To run the phpunit tests:
+To run all phpunit tests:
 
 ```bash
 docker-compose exec web ./vendor/bin/phpunit
@@ -189,6 +189,18 @@ docker-compose exec web ./vendor/bin/phpunit
 or, using the toolkit command as in the pipeline:
 ```bash
 docker-compose exec web ./vendor/bin/run toolkit:test-phpunit --junit
+```
+
+To run a specific test class:
+
+```bash
+docker-compose exec web ./vendor/bin/phpunit --testdox modules/oe_whitelabel_paragraphs/tests/src/Functional/ParagraphsTest.php
+```
+
+To run a single test method, use `--filter`:
+
+```bash
+docker-compose exec web ./vendor/bin/phpunit --testdox modules/oe_whitelabel_paragraphs/tests/src/Functional/ParagraphsTest.php --filter=testAccordionParagraph
 ```
 
 ## Rebuild assets during development

--- a/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
+++ b/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
@@ -139,9 +139,13 @@ function oe_whitelabel_preprocess_paragraph__oe_accordion(array &$variables): vo
   /** @var \Drupal\entity_reference_revisions\Plugin\Field\FieldType\EntityReferenceRevisionsItem $field_item */
   foreach ($variables['paragraph']->get('field_oe_paragraphs') as $field_item) {
     $paragraph = \Drupal::service('entity.repository')->getTranslationFromContext($field_item->entity);
+    // Use viewField with display settings from the configured view mode.
+    $display = \Drupal::service('entity_display.repository')->getViewDisplay('paragraph', $paragraph->bundle(), $variables['view_mode'] ?? 'default');
+    $title_settings = $display->getComponent('field_oe_text') ?: [];
+    $content_settings = $display->getComponent('field_oe_text_long') ?: [];
     $variables['items'][] = [
-      'title' => $builder->viewField($paragraph->get('field_oe_text')),
-      'content' => $builder->viewField($paragraph->get('field_oe_text_long')),
+      'title' => $builder->viewField($paragraph->get('field_oe_text'), $title_settings),
+      'content' => $builder->viewField($paragraph->get('field_oe_text_long'), $content_settings),
     ];
   }
 }

--- a/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
+++ b/modules/oe_whitelabel_paragraphs/oe_whitelabel_paragraphs.module
@@ -135,19 +135,23 @@ function oe_whitelabel_preprocess_paragraph__oe_accordion(array &$variables): vo
   // data structure.
   $builder = \Drupal::entityTypeManager()->getViewBuilder('paragraph');
   $variables['items'] = [];
+  $cacheability = CacheableMetadata::createFromRenderArray($variables);
 
   /** @var \Drupal\entity_reference_revisions\Plugin\Field\FieldType\EntityReferenceRevisionsItem $field_item */
   foreach ($variables['paragraph']->get('field_oe_paragraphs') as $field_item) {
     $paragraph = \Drupal::service('entity.repository')->getTranslationFromContext($field_item->entity);
     // Use viewField with display settings from the configured view mode.
     $display = \Drupal::service('entity_display.repository')->getViewDisplay('paragraph', $paragraph->bundle(), $variables['view_mode'] ?? 'default');
-    $title_settings = $display->getComponent('field_oe_text') ?: [];
-    $content_settings = $display->getComponent('field_oe_text_long') ?: [];
+    $cacheability->addCacheableDependency($display);
+    $title_settings = $display->getComponent('field_oe_text');
+    $content_settings = $display->getComponent('field_oe_text_long');
     $variables['items'][] = [
-      'title' => $builder->viewField($paragraph->get('field_oe_text'), $title_settings),
-      'content' => $builder->viewField($paragraph->get('field_oe_text_long'), $content_settings),
+      'title' => $title_settings ? $builder->viewField($paragraph->get('field_oe_text'), $title_settings) : [],
+      'content' => $content_settings ? $builder->viewField($paragraph->get('field_oe_text_long'), $content_settings) : [],
     ];
   }
+
+  $cacheability->applyTo($variables);
 }
 
 /**

--- a/modules/oe_whitelabel_paragraphs/tests/src/Functional/ParagraphsTest.php
+++ b/modules/oe_whitelabel_paragraphs/tests/src/Functional/ParagraphsTest.php
@@ -124,6 +124,21 @@ class ParagraphsTest extends BrowserTestBase {
    * Test Accordion paragraphs form.
    */
   public function testAccordionParagraph(): void {
+    // Test label display settings first.
+    $display = \Drupal::service('entity_display.repository')->getViewDisplay('paragraph', 'oe_accordion_item', 'default');
+
+    // Configure title field to show label above.
+    $title_component = $display->getComponent('field_oe_text') ?: [];
+    $title_component['label'] = 'above';
+    $display->setComponent('field_oe_text', $title_component);
+
+    // Configure content field to hide label.
+    $content_component = $display->getComponent('field_oe_text_long') ?: [];
+    $content_component['label'] = 'hidden';
+    $display->setComponent('field_oe_text_long', $content_component);
+
+    $display->save();
+
     $this->drupalGet('/node/add/paragraphs_test');
     $page = $this->getSession()->getPage();
     $page->pressButton('Add Accordion');
@@ -145,6 +160,25 @@ class ParagraphsTest extends BrowserTestBase {
     // Assert paragraph values are displayed correctly.
     $this->assertSession()->pageTextContains('Title item 1');
     $this->assertSession()->pageTextContains('Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
+
+    // Test that field display settings are respected.
+    // The title field should show its label since we set it to 'above'.
+    $field_definition = \Drupal::service('entity_field.manager')->getFieldDefinitions('paragraph', 'oe_accordion_item')['field_oe_text'];
+    $field_label = $field_definition->getLabel();
+    $this->assertSession()->pageTextContains($field_label);
+
+    // Test with hidden label setting.
+    $title_component['label'] = 'hidden';
+    $display->setComponent('field_oe_text', $title_component);
+    $display->save();
+
+    // Clear render cache and reload page.
+    \Drupal::service('cache.render')->invalidateAll();
+    $this->drupalGet('/node/1');
+
+    // Content should still be there but label should be hidden.
+    $this->assertSession()->pageTextContains('Title item 1');
+    $this->assertSession()->pageTextNotContains($field_label);
   }
 
   /**

--- a/modules/oe_whitelabel_paragraphs/tests/src/Functional/ParagraphsTest.php
+++ b/modules/oe_whitelabel_paragraphs/tests/src/Functional/ParagraphsTest.php
@@ -124,21 +124,6 @@ class ParagraphsTest extends BrowserTestBase {
    * Test Accordion paragraphs form.
    */
   public function testAccordionParagraph(): void {
-    // Test label display settings first.
-    $display = \Drupal::service('entity_display.repository')->getViewDisplay('paragraph', 'oe_accordion_item', 'default');
-
-    // Configure title field to show label above.
-    $title_component = $display->getComponent('field_oe_text') ?: [];
-    $title_component['label'] = 'above';
-    $display->setComponent('field_oe_text', $title_component);
-
-    // Configure content field to hide label.
-    $content_component = $display->getComponent('field_oe_text_long') ?: [];
-    $content_component['label'] = 'hidden';
-    $display->setComponent('field_oe_text_long', $content_component);
-
-    $display->save();
-
     $this->drupalGet('/node/add/paragraphs_test');
     $page = $this->getSession()->getPage();
     $page->pressButton('Add Accordion');
@@ -150,7 +135,7 @@ class ParagraphsTest extends BrowserTestBase {
 
     $values = [
       'title[0][value]' => 'Test Accordion',
-      'oe_w_paragraphs[0][subform][field_oe_paragraphs][0][subform][field_oe_text][0][value]' => 'Title item 1',
+      'oe_w_paragraphs[0][subform][field_oe_paragraphs][0][subform][field_oe_text][0][value]' => 'Accordion heading 1',
       'oe_w_paragraphs[0][subform][field_oe_paragraphs][0][subform][field_oe_text_long][0][value]' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
     ];
 
@@ -158,27 +143,21 @@ class ParagraphsTest extends BrowserTestBase {
     $this->drupalGet('/node/1');
 
     // Assert paragraph values are displayed correctly.
-    $this->assertSession()->pageTextContains('Title item 1');
+    $this->assertSession()->pageTextContains('Accordion heading 1');
     $this->assertSession()->pageTextContains('Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
 
-    // Test that field display settings are respected.
-    // The title field should show its label since we set it to 'above'.
-    $field_definition = \Drupal::service('entity_field.manager')->getFieldDefinitions('paragraph', 'oe_accordion_item')['field_oe_text'];
-    $field_label = $field_definition->getLabel();
-    $this->assertSession()->pageTextContains($field_label);
-
-    // Test with hidden label setting.
-    $title_component['label'] = 'hidden';
-    $display->setComponent('field_oe_text', $title_component);
+    // Test that field display settings are respected: removing a field from
+    // the display should hide it, and the render cache should be invalidated
+    // automatically without manual cache clearing.
+    $display = \Drupal::service('entity_display.repository')->getViewDisplay('paragraph', 'oe_accordion_item', 'default');
+    $display->removeComponent('field_oe_text_long');
     $display->save();
 
-    // Clear render cache and reload page.
-    \Drupal::service('cache.render')->invalidateAll();
     $this->drupalGet('/node/1');
 
-    // Content should still be there but label should be hidden.
-    $this->assertSession()->pageTextContains('Title item 1');
-    $this->assertSession()->pageTextNotContains($field_label);
+    // Title should still be visible, but the content field should be hidden.
+    $this->assertSession()->pageTextContains('Accordion heading 1');
+    $this->assertSession()->pageTextNotContains('Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
   }
 
   /**


### PR DESCRIPTION
The oe_accordion preprocessing was ignoring field display configuration
by using viewField() without display settings. This prevented site builders
from controlling label visibility and field formatters through the UI.

Now retrieves and applies the configured display settings for the current
view mode, ensuring proper field rendering respects user configuration.