### PR TITLE
OEL-4032: Use 'gap' for icon spacing in button and link

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "drupal/daterange_compact": "^2.0.1",
         "drupal/twig_field_value": "^2.0.2",
         "openeuropa/composer-artifacts": "^1.0.0-alpha1",
-        "openeuropa/oe_bootstrap_theme": "0.4032.202602121800 as 1.32.0"
+        "openeuropa/oe_bootstrap_theme": "0.4032.202602122230 as 1.32.0"
     },
     "require-dev": {
         "composer/installers": "^1.11 || ^2.3",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "drupal/daterange_compact": "^2.0.1",
         "drupal/twig_field_value": "^2.0.2",
         "openeuropa/composer-artifacts": "^1.0.0-alpha1",
-        "openeuropa/oe_bootstrap_theme": "0.4032.202602042100 as 1.32.0"
+        "openeuropa/oe_bootstrap_theme": "0.4032.202602121610 as 1.32.0"
     },
     "require-dev": {
         "composer/installers": "^1.11 || ^2.3",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "drupal/daterange_compact": "^2.0.1",
         "drupal/twig_field_value": "^2.0.2",
         "openeuropa/composer-artifacts": "^1.0.0-alpha1",
-        "openeuropa/oe_bootstrap_theme": "0.4032.202602121610 as 1.32.0"
+        "openeuropa/oe_bootstrap_theme": "0.4032.202602121800 as 1.32.0"
     },
     "require-dev": {
         "composer/installers": "^1.11 || ^2.3",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "drupal/daterange_compact": "^2.0.1",
         "drupal/twig_field_value": "^2.0.2",
         "openeuropa/composer-artifacts": "^1.0.0-alpha1",
-        "openeuropa/oe_bootstrap_theme": "^1.32"
+        "openeuropa/oe_bootstrap_theme": "0.4032.202602042100 as 1.32.0"
     },
     "require-dev": {
         "composer/installers": "^1.11 || ^2.3",

--- a/modules/oe_whitelabel_multilingual/oe_whitelabel_multilingual.module
+++ b/modules/oe_whitelabel_multilingual/oe_whitelabel_multilingual.module
@@ -49,7 +49,6 @@ function oe_whitelabel_multilingual_preprocess_links__oe_multilingual_content_la
       'label' => $languages[$translation->language()->getId()]->getName(),
       'current' => TRUE,
       'icon_position' => 'before',
-      'remove_icon_spacers' => FALSE,
       'icon' => [
         'name' => 'check-lg',
         'path' => $variables['bcl_icon_path'],

--- a/modules/oe_whitelabel_multilingual/oe_whitelabel_multilingual.module
+++ b/modules/oe_whitelabel_multilingual/oe_whitelabel_multilingual.module
@@ -53,7 +53,6 @@ function oe_whitelabel_multilingual_preprocess_links__oe_multilingual_content_la
         'name' => 'check-lg',
         'path' => $variables['bcl_icon_path'],
         'size' => 'xs',
-        '#attributes' => ['class' => ['me-2']],
       ],
     ];
   }

--- a/modules/oe_whitelabel_search/tests/src/Kernel/SearchBlockTest.php
+++ b/modules/oe_whitelabel_search/tests/src/Kernel/SearchBlockTest.php
@@ -230,7 +230,7 @@ class SearchBlockTest extends KernelTestBase {
     $this->assertStringContainsString('btn', $button->attr('class'));
     $this->assertStringContainsString('btn-primary', $button->attr('class'));
     $this->assertStringContainsString('btn-md', $button->attr('class'));
-    $icon = $button->filter('.bi.icon--s.me-md-2-5.bcl-search-form__btn_icon');
+    $icon = $button->filter('.bi.icon--s.bcl-search-form__btn_icon');
     $this->assertCount(1, $icon);
     $label = $button->filter('span.d-none.d-lg-inline-block');
     $this->assertCount(1, $label);

--- a/modules/oe_whitelabel_search/tests/src/Kernel/SearchBlockTest.php
+++ b/modules/oe_whitelabel_search/tests/src/Kernel/SearchBlockTest.php
@@ -231,7 +231,7 @@ class SearchBlockTest extends KernelTestBase {
     $this->assertStringContainsString('btn-primary', $button->attr('class'));
     $this->assertStringContainsString('btn-md', $button->attr('class'));
     $this->assertStringContainsString('gap-2-5', $button->attr('class'));
-    $icon = $button->filter('.bi.icon--s.bcl-search-form__btn_icon');
+    $icon = $button->filter('.bi.icon--fluid.bcl-search-form__btn_icon');
     $this->assertCount(1, $icon);
     $label = $button->filter('span.d-none.d-lg-inline-block');
     $this->assertCount(1, $label);

--- a/modules/oe_whitelabel_search/tests/src/Kernel/SearchBlockTest.php
+++ b/modules/oe_whitelabel_search/tests/src/Kernel/SearchBlockTest.php
@@ -230,6 +230,7 @@ class SearchBlockTest extends KernelTestBase {
     $this->assertStringContainsString('btn', $button->attr('class'));
     $this->assertStringContainsString('btn-primary', $button->attr('class'));
     $this->assertStringContainsString('btn-md', $button->attr('class'));
+    $this->assertStringContainsString('gap-2-5', $button->attr('class'));
     $icon = $button->filter('.bi.icon--s.bcl-search-form__btn_icon');
     $this->assertCount(1, $icon);
     $label = $button->filter('span.d-none.d-lg-inline-block');

--- a/resources/sass/components/_header.scss
+++ b/resources/sass/components/_header.scss
@@ -1,7 +1,5 @@
 .top-navigation-link {
-  display: flex;
   align-items: center;
-  gap: 0.75rem;
   padding: 0.375rem 0.75rem;
   border-radius: 0.25rem;
   &.active,

--- a/templates/overrides/navigation/block--oe-authentication-login-block.html.twig
+++ b/templates/overrides/navigation/block--oe-authentication-login-block.html.twig
@@ -29,7 +29,6 @@
       size: 'fluid',
     },
     icon_position: 'before',
-    remove_icon_spacers: true,
     attributes: extra_attributes
   }) }}
 </div>

--- a/templates/overrides/navigation/block--oe-authentication-login-block.html.twig
+++ b/templates/overrides/navigation/block--oe-authentication-login-block.html.twig
@@ -24,6 +24,7 @@
   {{ pattern('link', {
     label: link_title,
     path: content['#url']|render,
+    icon_display: 'inline-flex',
     icon: {
       name: icon_name,
       size: 'fluid',

--- a/templates/overrides/navigation/links--language-block.html.twig
+++ b/templates/overrides/navigation/links--language-block.html.twig
@@ -38,7 +38,6 @@
     size: 'fluid',
   },
   icon_position: 'before',
-  remove_icon_spacers: true,
   attributes: extra_attributes
 }) }}
 

--- a/templates/overrides/navigation/links--language-block.html.twig
+++ b/templates/overrides/navigation/links--language-block.html.twig
@@ -33,6 +33,7 @@
 {{ pattern('link', {
   label: _link_title,
   path: _language_link.href,
+  icon_display: 'inline-flex',
   icon: {
     name: 'globe2',
     size: 'fluid',

--- a/templates/overrides/search/input--submit--header--oe-whitelabel-search-form.html.twig
+++ b/templates/overrides/search/input--submit--header--oe-whitelabel-search-form.html.twig
@@ -14,7 +14,6 @@
     'attributes': create_attribute({
       'class': [
         'd-inline-block',
-        'me-md-2-5',
         'bcl-search-form__btn_icon',
       ]
     })

--- a/templates/overrides/search/input--submit--header--oe-whitelabel-search-form.html.twig
+++ b/templates/overrides/search/input--submit--header--oe-whitelabel-search-form.html.twig
@@ -7,17 +7,6 @@
  */
 #}
 {% set label %}
-  {{ pattern('icon', {
-    'name': 'search',
-    'path': bcl_icon_path,
-    'size': 's',
-    'attributes': create_attribute({
-      'class': [
-        'd-inline-block',
-        'bcl-search-form__btn_icon',
-      ]
-    })
-  }) }}
   {% if element['#value'] is not empty %}
     <span class="d-none d-lg-inline-block">{{ element['#value']|t }}</span>
   {% endif %}
@@ -25,6 +14,17 @@
 {{ pattern('button', {
   'variant': 'primary',
   'label': label,
+  'icon': {
+    'name': 'search',
+    'path': bcl_icon_path,
+    'attributes': create_attribute({
+      'class': [
+        'bcl-search-form__btn_icon',
+      ]
+    })
+  },
+  'icon_position': 'before',
+  'icon_display': 'inline-flex',
   'type': 'submit',
   'attributes': attributes
     .addClass([

--- a/templates/overrides/search/input--submit--header--oe-whitelabel-search-form.html.twig
+++ b/templates/overrides/search/input--submit--header--oe-whitelabel-search-form.html.twig
@@ -17,11 +17,7 @@
   'icon': {
     'name': 'search',
     'path': bcl_icon_path,
-    'attributes': create_attribute({
-      'class': [
-        'bcl-search-form__btn_icon',
-      ]
-    })
+    'attributes': create_attribute().addClass(['bcl-search-form__btn_icon']),
   },
   'icon_position': 'before',
   'icon_display': 'inline-flex',

--- a/templates/overrides/search/input--submit--header--oe-whitelabel-search-form.html.twig
+++ b/templates/overrides/search/input--submit--header--oe-whitelabel-search-form.html.twig
@@ -20,7 +20,6 @@
     'attributes': create_attribute().addClass(['bcl-search-form__btn_icon']),
   },
   'icon_position': 'before',
-  'icon_display': 'inline-flex',
   'type': 'submit',
   'attributes': attributes
     .addClass([

--- a/tests/src/Kernel/AuthenticationBlockTest.php
+++ b/tests/src/Kernel/AuthenticationBlockTest.php
@@ -107,6 +107,8 @@ class AuthenticationBlockTest extends KernelTestBase {
   protected function assertAuthenticationLinkClasses(Crawler $link, bool $logged_in): void {
     $classes = $link->attr('class') ?? '';
     $this->assertStringContainsString('top-navigation-link', $classes);
+    $this->assertStringContainsString('d-inline-flex', $classes);
+    $this->assertStringContainsString('gap-2-5', $classes);
     if ($logged_in) {
       $this->assertStringContainsString('active', $classes);
     }

--- a/tests/src/Kernel/AuthenticationBlockTest.php
+++ b/tests/src/Kernel/AuthenticationBlockTest.php
@@ -25,6 +25,7 @@ class AuthenticationBlockTest extends KernelTestBase {
     'system',
     'ui_patterns',
     'ui_patterns_library',
+    'ui_patterns_settings',
     'user',
   ];
 

--- a/tests/src/Kernel/MultilingualBlockTest.php
+++ b/tests/src/Kernel/MultilingualBlockTest.php
@@ -25,6 +25,7 @@ class MultilingualBlockTest extends KernelTestBase {
     'system',
     'ui_patterns',
     'ui_patterns_library',
+    'ui_patterns_settings',
   ];
 
   /**

--- a/tests/src/Kernel/MultilingualBlockTest.php
+++ b/tests/src/Kernel/MultilingualBlockTest.php
@@ -81,6 +81,8 @@ class MultilingualBlockTest extends KernelTestBase {
     $this->assertSame('#', $link->attr('href'));
     $link_classes = $link->attr('class') ?? '';
     $this->assertStringContainsString('top-navigation-link', $link_classes);
+    $this->assertStringContainsString('d-inline-flex', $link_classes);
+    $this->assertStringContainsString('gap-2-5', $link_classes);
     $icon = $link->filter('svg');
     $this->assertCount(1, $icon);
     $icon_classes = $icon->attr('class') ?? '';


### PR DESCRIPTION
- See https://github.com/openeuropa/oe_bootstrap_theme/pull/537
- See https://github.com/openeuropa/bootstrap-component-library/pull/733