### PR TITLE
OEL-4455: Require (dev) drupal/modal_page:^6.0-beta11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "drupal/extra_field": "^2.3 || ^3.0@beta",
         "drupal/facets_form": "^1.0.0-alpha6",
         "drupal/field_group": "^3.4",
-        "drupal/modal_page": "^6.0-beta10",
+        "drupal/modal_page": "^6.0-beta11",
         "drupal/paragraphs": "^1.17",
         "drupal/search_api": "^1.29",
         "drupal/search_api_autocomplete": "^1.7",


### PR DESCRIPTION
This make sure the new patch version will apply.

- follows #413 

other:
- follows #408 
- follows #390 