### PR TITLE
OEL-0000: Use drush cset for error level, don't write to settings.override.php.

### DIFF
--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -41,6 +41,7 @@ drupal:
     - { task: "exec", command: "./vendor/bin/drush config-set system.theme admin claro -y" }
     - { task: "exec", command: "./vendor/bin/drush config-set node.settings use_admin_theme 1 -y" }
     - { task: "exec", command: "./vendor/bin/drush config-set cas.settings forced_login.enabled 0 -y" }
+    - { task: "exec", command: "./vendor/bin/drush config-set system.logging error_level verbose -y" }
     - { task: "exec", command: "./vendor/bin/drush cr" }
   additional_settings: |
     $settings['file_scan_ignore_directories'] = [
@@ -70,15 +71,6 @@ commands:
     - { task: "run", command: "drupal:drush-setup" }
     - { task: "run", command: "drupal:settings-setup" }
     - { task: "run", command: "setup:phpunit" }
-    - { task: "run", command: "setup:settings-local" }
-
-  setup:settings-local:
-    - task: "append"
-      file: "build/sites/default/settings.override.php"
-      text: |
-        <?php
-
-        $config['system.logging']['error_level'] = 'verbose';
 
   setup:phpunit:
     - { task: "process", source: "phpunit.xml.dist", destination: "phpunit.xml" }


### PR DESCRIPTION
The settings.override.php is controlled by toolkit.

When we moved from task-runner to toolkit (to use gitlab CI), we changed the `setup:settings-local` to add `<?php`.
The problem is this needed to support two cases:
- When the site was not installed yet, settings.override.php would not exist, so we need to add `<?php`.
- When the site is already installed and we run composer install afterwards, now we need to append to an existing file, so we don't want to add `<?php`. Also we would not want to remove or fully replace the file, because toolkit already added some stuff that we must keep.
- When we run composer install multiple times, we don't want to append anything, otherwise it will cause duplication.

The solution is to use `drush cset` as in other projects.