### PR TITLE
OEL-4559: Header search button must have accessible / discernible text

### DIFF
--- a/templates/overrides/search/input--submit--header-top--oe-whitelabel-search-form.html.twig
+++ b/templates/overrides/search/input--submit--header-top--oe-whitelabel-search-form.html.twig
@@ -19,5 +19,6 @@
       'rounded-end',
       'px-3',
     ])
+    .setAttribute('aria-label', 'Search'|t)
 }) }}
 {{ children }}


### PR DESCRIPTION
Accessibility – add aria-label to search submit button